### PR TITLE
Update hoek version to be ^2.8.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "node": ">=0.10.32"
   },
   "dependencies": {
-    "hoek": "2.x.x"
+    "hoek": "^2.8.x"
   },
   "devDependencies": {
     "lab": "5.x.x"


### PR DESCRIPTION
Hoek introduced `.contain()`, which is used by methods such as Code's `.include()`, in version 2.8.0. The package.json specified version 2.x.x, which lead to the possibility of this method being undefined. This PR updates the version of Hoek to prevent this.
