### PR TITLE
Reset flags after each assertion

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -57,6 +57,7 @@ internals.Assertion.prototype.assert = function (result, verb, actual, expected)
     delete internals.locations[this._location];
 
     if (this._flags.not ? !result : result) {
+        this._flags = {};
         return this;
     }
 

--- a/test/index.js
+++ b/test/index.js
@@ -176,6 +176,27 @@ describe('expect()', function () {
         done();
     });
 
+    it('resets flags between chained assertions', function (done) {
+
+        var exception = false;
+        try {
+
+            Code.expect('abc').to.contain('a').and.to.not.contain('d');
+            Code.expect('abc').to.not.contain('d').and.to.contain('a');
+            Code.expect('abc').to.not.contain('d').and.to.not.contain('e');
+            Code.expect('abc').to.contain('a').and.to.not.contain('d').and.to.contain('c').to.not.contain('f');
+            Code.expect(function () {}).to.not.throw().and.to.be.a.function();
+            Code.expect(10).to.not.be.about(8, 1).and.to.be.about(9, 1);
+            Code.expect(10).to.be.about(9, 1).and.to.not.be.about(8, 1);
+        }
+        catch (err) {
+            exception = err;
+        }
+
+        Hoek.assert(!exception, exception);
+        done();
+    });
+
     describe('assertion', function () {
 
         describe('argument()', function () {


### PR DESCRIPTION
Flags were not reset on chained assertions leading to false failures like the ones shown in #9. This commit resets the flags after each passed assertion. Closes #9
