### PR TITLE
Verify deep.equal() functionality after changes to Hoek.deepEqual()

### DIFF
--- a/test/index.js
+++ b/test/index.js
@@ -1071,6 +1071,9 @@ describe('expect()', function () {
                 var exception = false;
                 try {
                     Code.expect(['abc']).to.deep.equal(['abc']);
+                    Code.expect({a: 1}).to.deep.equal({a: 1});
+                    Code.expect({}).to.not.deep.equal({a: 1});
+                    Code.expect({a: 1}).to.not.deep.equal({});
                 }
                 catch (err) {
                     exception = err;


### PR DESCRIPTION
Add test for #15 after Hoek changes in https://github.com/hapijs/hoek/commit/7ffc68a6babd223425651219a099229d3687343c.

Closes #15