### PR TITLE
added support for optional truncating

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -269,7 +269,7 @@ internals.display = function (value) {
 
     var string = NodeUtil.inspect(value);
     if (!exports.truncate) {
-      return string;
+        return string;
     }
 
     if (string.length <= 40) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -13,6 +13,7 @@ var internals = {
     count: 0
 };
 
+exports.truncate = true;
 
 exports.expect = function (value, prefix) {
 
@@ -267,6 +268,10 @@ internals.addMethod(['throw', 'throws'], function (/* type, message */) {
 internals.display = function (value) {
 
     var string = NodeUtil.inspect(value);
+    if (!exports.truncate) {
+      return string;
+    }
+
     if (string.length <= 40) {
         return string;
     }

--- a/test/index.js
+++ b/test/index.js
@@ -137,12 +137,13 @@ describe('expect()', function () {
     it('asserts on invalid condition (large array, display not truncated)', function (done) {
 
         var exception = false;
+        var origTruncate = Code.truncate;
         try {
             Code.truncate = false;
             Code.expect([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18]).to.be.a.string();
         }
         catch (err) {
-            Code.truncate = true;
+            Code.truncate = origTruncate;
             exception = err;
         }
 
@@ -167,12 +168,13 @@ describe('expect()', function () {
     it('asserts on invalid condition (large object, display not truncated)', function (done) {
 
         var exception = false;
+        var origTruncate = Code.truncate;
         try {
             Code.truncate = false;
             Code.expect({ a: 1, b: 2, c: 3, d: 4, e: 5, f: 6, g: 7, h: 8, i: 9, j: 10 }).to.be.a.string();
         }
         catch (err) {
-            Code.truncate = true;
+            Code.truncate = origTruncate;
             exception = err;
         }
 
@@ -197,12 +199,13 @@ describe('expect()', function () {
     it('asserts on invalid condition (long object values, display not truncated)', function (done) {
 
         var exception = false;
+        var origTruncate = Code.truncate;
         try {
             Code.truncate = false;
             Code.expect({ a: 12345678901234567890, b: 12345678901234567890 }).to.be.a.string();
         }
         catch (err) {
-            Code.truncate = true;
+            Code.truncate = origTruncate;
             exception = err;
         }
 
@@ -227,12 +230,13 @@ describe('expect()', function () {
     it('asserts on invalid condition (long string, display not truncated)', function (done) {
 
         var exception = false;
+        var origTruncate = Code.truncate;
         try {
             Code.truncate = false;
             Code.expect('{ a: 1, b: 2, c: 3, d: 4, e: 5, f: 6, g: 7, h: 8, i: 9, j: 10 }').to.be.a.number();
         }
         catch (err) {
-            Code.truncate = true;
+            Code.truncate = origTruncate;
             exception = err;
         }
 

--- a/test/index.js
+++ b/test/index.js
@@ -120,7 +120,7 @@ describe('expect()', function () {
         done();
     });
 
-    it('asserts on invalid condition (large array)', function (done) {
+    it('asserts on invalid condition (large array, display truncated)', function (done) {
 
         var exception = false;
         try {
@@ -134,7 +134,23 @@ describe('expect()', function () {
         done();
     });
 
-    it('asserts on invalid condition (large object)', function (done) {
+    it('asserts on invalid condition (large array, display not truncated)', function (done) {
+
+        var exception = false;
+        try {
+            Code.truncate = false;
+            Code.expect([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18]).to.be.a.string();
+        }
+        catch (err) {
+            Code.truncate = true;
+            exception = err;
+        }
+
+        Hoek.assert(exception.message === 'Expected [ 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18 ] to be a string but got \'array\'', exception);
+        done();
+    });
+
+    it('asserts on invalid condition (large object, display truncated)', function (done) {
 
         var exception = false;
         try {
@@ -148,7 +164,23 @@ describe('expect()', function () {
         done();
     });
 
-    it('asserts on invalid condition (long object values)', function (done) {
+    it('asserts on invalid condition (large object, display not truncated)', function (done) {
+
+        var exception = false;
+        try {
+            Code.truncate = false;
+            Code.expect({ a: 1, b: 2, c: 3, d: 4, e: 5, f: 6, g: 7, h: 8, i: 9, j: 10 }).to.be.a.string();
+        }
+        catch (err) {
+            Code.truncate = true;
+            exception = err;
+        }
+
+        Hoek.assert(exception.message === 'Expected { a: 1, b: 2, c: 3, d: 4, e: 5, f: 6, g: 7, h: 8, i: 9, j: 10 } to be a string but got \'object\'', exception);
+        done();
+    });
+
+    it('asserts on invalid condition (long object values, display truncated)', function (done) {
 
         var exception = false;
         try {
@@ -162,7 +194,23 @@ describe('expect()', function () {
         done();
     });
 
-    it('asserts on invalid condition (long string)', function (done) {
+    it('asserts on invalid condition (long object values, display not truncated)', function (done) {
+
+        var exception = false;
+        try {
+            Code.truncate = false;
+            Code.expect({ a: 12345678901234567890, b: 12345678901234567890 }).to.be.a.string();
+        }
+        catch (err) {
+            Code.truncate = true;
+            exception = err;
+        }
+
+        Hoek.assert(exception.message === 'Expected { a: 12345678901234567000, b: 12345678901234567000 } to be a string but got \'object\'', exception);
+        done();
+    });
+
+    it('asserts on invalid condition (long string, display truncated)', function (done) {
 
         var exception = false;
         try {
@@ -173,6 +221,22 @@ describe('expect()', function () {
         }
 
         Hoek.assert(exception.message === 'Expected \'{ a: 1, b: 2, c: 3, d: 4, e: 5, f: 6, g...\' to be a number but got \'string\'', exception);
+        done();
+    });
+
+    it('asserts on invalid condition (long string, display not truncated)', function (done) {
+
+        var exception = false;
+        try {
+            Code.truncate = false;
+            Code.expect('{ a: 1, b: 2, c: 3, d: 4, e: 5, f: 6, g: 7, h: 8, i: 9, j: 10 }').to.be.a.number();
+        }
+        catch (err) {
+            Code.truncate = true;
+            exception = err;
+        }
+
+        Hoek.assert(exception.message === 'Expected \'{ a: 1, b: 2, c: 3, d: 4, e: 5, f: 6, g: 7, h: 8, i: 9, j: 10 }\' to be a number but got \'string\'', exception);
         done();
     });
 


### PR DESCRIPTION
The truncating of display messages was intentional back in commit 3f65ae1d.

This change allows a module wide setting to enable or disable the truncation of the message display.  This could then be set by flags in lab.

Fixes #14 
