### PR TITLE
readme typo and better message

### DIFF
--- a/README.md
+++ b/README.md
@@ -524,7 +524,7 @@ Asserts that the reference value is between but not equal (`from < value < to`) 
 var Code = require('code');
 var expect = Code.expect;
 
-expect(15).to.be.within(10, 20);
+expect(15).to.be.between(10, 20);
 ```
 
 #### `about(value, delta)`

--- a/lib/index.js
+++ b/lib/index.js
@@ -145,7 +145,7 @@ internals.addMethod(['exist', 'exists'], function () {
 
 internals.addMethod('empty', function () {
 
-    internals.assert(this, typeof this._ref === 'object' || typeof this._ref === 'string', 'Can only assert empty on object or string');
+    internals.assert(this, typeof this._ref === 'object' || typeof this._ref === 'string', 'Can only assert empty on object, array or string');
 
     var length = this._ref.length !== undefined ? this._ref.length : Object.keys(this._ref).length;
     return this.assert(!length, 'be empty');
@@ -154,7 +154,7 @@ internals.addMethod('empty', function () {
 
 internals.addMethod('length', function (size) {
 
-    internals.assert(this, typeof this._ref === 'object' || typeof this._ref === 'string', 'Can only assert empty on object or string');
+    internals.assert(this, typeof this._ref === 'object' || typeof this._ref === 'string', 'Can only assert empty on object, array or string');
 
     var length = this._ref.length !== undefined ? this._ref.length : Object.keys(this._ref).length;
     return this.assert(length === size, 'have a length of ' + size, length);


### PR DESCRIPTION
for `.length()` and `.empty()` methods