### PR TITLE
Allow prototypes to be ignored in deep.equal()

### DIFF
--- a/README.md
+++ b/README.md
@@ -426,13 +426,15 @@ var expect = Code.expect;
 expect('abcd').to.have.length(4);
 ```
 
-#### `equal(value)`
+#### `equal(value[, options])`
 
 Aliases: `equals()`
 
 Asserts that the reference value equals the provided value (`deep` is required to compare non-literal
 types) where:
 - `value` - the value to compare to.
+- `options` - optional object specifying comparison options. This is only used on
+deep comparisons, and is ignored otherwise.
 
 ```js
 var Code = require('code');
@@ -440,6 +442,18 @@ var expect = Code.expect;
 
 expect(5).to.equal(5);
 expect({ a: 1 }).to.deep.equal({ a: 1 });
+```
+
+Deep comparisons are performed using
+[`Hoek.deepEqual()`](https://github.com/hapijs/hoek#deepequalb-a-options). The
+optional `options` argument is passed directly to `Hoek.deepEqual()`. An example
+deep comparison which ignores object prototypes is shown below.
+
+```js
+var Code = require('code');
+var expect = Code.expect;
+
+expect(Object.create(null)).to.deep.equal({}, { prototype: false });
 ```
 
 #### `above(value)`

--- a/lib/index.js
+++ b/lib/index.js
@@ -161,9 +161,11 @@ internals.addMethod('length', function (size) {
 });
 
 
-internals.addMethod(['equal', 'equals'], function (value) {
+internals.addMethod(['equal', 'equals'], function (value, options) {
 
-    var compare = (this._flags.deep ? Hoek.deepEqual : function (a, b) { return a === b; });
+    var compare = this._flags.deep ? function (a, b) { return Hoek.deepEqual(a, b, options); } :
+                                     function (a, b) { return a === b; };
+
     return this.assert(compare(this._ref, value), 'equal specified value', this._ref, value);
 });
 

--- a/test/index.js
+++ b/test/index.js
@@ -1074,6 +1074,8 @@ describe('expect()', function () {
                     Code.expect({a: 1}).to.deep.equal({a: 1});
                     Code.expect({}).to.not.deep.equal({a: 1});
                     Code.expect({a: 1}).to.not.deep.equal({});
+                    Code.expect(Object.create(null)).to.not.deep.equal({});
+                    Code.expect(Object.create(null)).to.deep.equal({}, { prototype: false });
                 }
                 catch (err) {
                     exception = err;


### PR DESCRIPTION
Closes #24 