### PR TITLE
Added new global setting to ignore prototypes.

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ Lead Maintainer - [Colin Ihrig](https://github.com/cjihrig)
     - [`incomplete()`](#incomplete)
     - [Settings](#settings)
         - [`truncateMessages`](#truncatemessages)
+        - [`comparePrototypes`](#compareprototypes)
 
 ## Example
 
@@ -676,15 +677,15 @@ Code.settings.truncateMessages = false;
 expect(foo).to.deep.equal([]);
 ```
 
-#### `prototype`
+#### `comparePrototypes`
 
-A boolean value that, when `false`, ignores objects prototypes when doing a deep comparison. Defaults to `true`.
+A boolean value that, when `false`, ignores object prototypes when doing a deep comparison. Defaults to `true`.
 
 ```js
 var Code = require('code');
 var expect = Code.expect;
 var foo = Object.create(null);
 
-Code.setting.prototype = false;
+Code.setting.comparePrototypes = false;
 expect(foo).to.deep.equal({});
 ```

--- a/README.md
+++ b/README.md
@@ -675,3 +675,16 @@ var foo = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12];
 Code.settings.truncateMessages = false;
 expect(foo).to.deep.equal([]);
 ```
+
+#### `prototype`
+
+A boolean value that, when `false`, ignores objects prototypes when doing a deep comparison. Defaults to `true`.
+
+```js
+var Code = require('code');
+var expect = Code.expect;
+var foo = Object.create(null);
+
+Code.setting.prototype = false;
+expect(foo).to.deep.equal({});
+```

--- a/lib/index.js
+++ b/lib/index.js
@@ -14,7 +14,8 @@ var internals = {
 };
 
 exports.settings = {
-    truncateMessages: true
+    truncateMessages: true,
+    prototype: true
 };
 
 exports.expect = function (value, prefix) {
@@ -167,9 +168,11 @@ internals.addMethod('length', function (size) {
 
 internals.addMethod(['equal', 'equals'], function (value, options) {
 
+    options = options || {};
+    var settings = Hoek.applyToDefaults(exports.settings, options);
     var deepCompare = function (a, b) {
 
-        return Hoek.deepEqual(a, b, options);
+        return Hoek.deepEqual(a, b, settings);
     };
 
     var shallowCompare = function (a, b) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -15,7 +15,7 @@ var internals = {
 
 exports.settings = {
     truncateMessages: true,
-    prototype: true
+    comparePrototypes: true
 };
 
 exports.expect = function (value, prefix) {
@@ -169,7 +169,7 @@ internals.addMethod('length', function (size) {
 internals.addMethod(['equal', 'equals'], function (value, options) {
 
     options = options || {};
-    var settings = Hoek.applyToDefaults(exports.settings, options);
+    var settings = Hoek.applyToDefaults({ prototype: exports.settings.comparePrototypes }, options);
     var deepCompare = function (a, b) {
 
         return Hoek.deepEqual(a, b, settings);

--- a/test/index.js
+++ b/test/index.js
@@ -282,6 +282,30 @@ describe('expect()', function () {
         done();
     });
 
+    it('uses the global prototype setting when doing deep compares on objects', function (done) {
+
+        var origPrototype = Code.settings.prototype;
+        var exception = false;
+
+        Code.settings.prototype = false;
+
+        try {
+
+            var obj = Object.create(null);
+            Code.expect({}).to.deep.equal(obj);
+            obj.foo = 'bar';
+            Code.expect({ foo: 'bar' }).to.deep.equal(obj);
+            Code.expect({ foo: 'bar' }).to.deep.equal({ foo: 'bar' });
+        }
+        catch (err) {
+            exception = err;
+        }
+
+        Hoek.assert(!exception, exception);
+        Code.settings.prototype = origPrototype;
+        done();
+    });
+
     describe('assertion', function () {
 
         describe('argument()', function () {

--- a/test/index.js
+++ b/test/index.js
@@ -284,10 +284,10 @@ describe('expect()', function () {
 
     it('uses the global prototype setting when doing deep compares on objects', function (done) {
 
-        var origPrototype = Code.settings.prototype;
+        var origPrototype = Code.settings.comparePrototypes;
         var exception = false;
 
-        Code.settings.prototype = false;
+        Code.settings.comparePrototypes = false;
 
         try {
 
@@ -301,8 +301,8 @@ describe('expect()', function () {
             exception = err;
         }
 
+        Code.settings.comparePrototypes = origPrototype;
         Hoek.assert(!exception, exception);
-        Code.settings.prototype = origPrototype;
         done();
     });
 


### PR DESCRIPTION
This will allow you to ignore the prototype object for all deep object comparisons.