### PR TITLE
Add error type (fixes #61)

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -169,6 +169,21 @@ internals.addMethod = function (names, fn) {
     internals.addMethod(word, method);
 });
 
+internals.addMethod('error', function (/*type, message*/) {
+
+    const type = arguments.length && typeof arguments[0] !== 'string' && !(arguments[0] instanceof RegExp) ? arguments[0] : Error;
+    const lastArg = arguments[1] || arguments[0];
+    const message = typeof lastArg === 'string' || lastArg instanceof RegExp ? lastArg : null;
+    const err = this._ref;
+
+    this.assert(err instanceof type, 'be an error with ' + (type.name || 'provided') + ' type');
+
+    if (message !== null) {
+        const error = err.message || '';
+        this.assert(typeof message === 'string' ? error === message : error.match(message), 'be an error with specified message', error, message);
+    }
+});
+
 
 [true, false, null, undefined].forEach((value) => {
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -176,7 +176,9 @@ internals.addMethod('error', function (/*type, message*/) {
     const message = typeof lastArg === 'string' || lastArg instanceof RegExp ? lastArg : null;
     const err = this._ref;
 
-    this.assert(err instanceof type, 'be an error with ' + (type.name || 'provided') + ' type');
+    if (!this._flags.not || message === null) {
+        this.assert(err instanceof type, 'be an error with ' + (type.name || 'provided') + ' type');
+    }
 
     if (message !== null) {
         const error = err.message || '';

--- a/test/index.js
+++ b/test/index.js
@@ -514,6 +514,27 @@ describe('expect()', () => {
                 done();
             });
 
+            it('validates assertion (not error)', (done) => {
+
+                const Custom = function () { };
+                Hoek.inherits(Custom, Error);
+
+                let exception = false;
+                try {
+                    Code.expect(false).to.not.be.an.error();
+                    Code.expect(new Error('kaboom')).to.not.be.an.error('baboom');
+                    Code.expect(new Error('kaboom')).to.not.be.an.error(Error, 'baboom');
+                    Code.expect(new Error()).to.not.be.an.error(Custom);
+                    Code.expect(new Error('kaboom')).to.not.be.an.error(Custom, 'baboom');
+                }
+                catch (err) {
+                    exception = err;
+                }
+
+                Hoek.assert(!exception, exception);
+                done();
+            });
+
             it('invalidates assertion', (done) => {
 
                 let exception = false;

--- a/test/index.js
+++ b/test/index.js
@@ -496,6 +496,174 @@ describe('expect()', () => {
             });
         });
 
+        describe('error()', () => {
+
+            const error = new Error('kaboom');
+
+            it('validates assertion', (done) => {
+
+                let exception = false;
+                try {
+                    Code.expect(error).to.be.an.error();
+                }
+                catch (err) {
+                    exception = err;
+                }
+
+                Hoek.assert(!exception, exception);
+                done();
+            });
+
+            it('invalidates assertion', (done) => {
+
+                let exception = false;
+                try {
+                    Code.expect(false).to.be.an.error();
+                }
+                catch (err) {
+                    exception = err;
+                }
+
+                Hoek.assert(exception.message === 'Expected false to be an error with Error type', exception);
+                done();
+            });
+
+            it('validates assertion (message)', (done) => {
+
+                let exception = false;
+                try {
+                    Code.expect(error).to.be.an.error('kaboom');
+                }
+                catch (err) {
+                    exception = err;
+                }
+
+                Hoek.assert(!exception, exception);
+                done();
+            });
+
+            it('validates assertion (empty message)', (done) => {
+
+                let exception = false;
+                try {
+                    Code.expect(new Error('')).to.be.an.error('');
+                }
+                catch (err) {
+                    exception = err;
+                }
+
+                Hoek.assert(!exception, exception);
+                done();
+            });
+
+            it('validates assertion (message regex)', (done) => {
+
+                let exception = false;
+                try {
+                    Code.expect(error).to.be.an.error(/boom/);
+                }
+                catch (err) {
+                    exception = err;
+                }
+
+                Hoek.assert(!exception, exception);
+                done();
+            });
+
+            it('validates assertion (missing message)', (done) => {
+
+                const Custom = function () { };
+                Hoek.inherits(Custom, Error);
+
+                let exception = false;
+                try {
+                    Code.expect(new Custom()).to.be.an.error('kaboom');
+                }
+                catch (err) {
+                    exception = err;
+                }
+
+                Hoek.assert(exception.message === 'Expected [Error] to be an error with specified message', exception);
+                done();
+            });
+
+
+            it('invalidates assertion (empty message)', (done) => {
+
+                let exception = false;
+                try {
+                    Code.expect(new Error('kaboom')).to.be.an.error('');
+                }
+                catch (err) {
+                    exception = err;
+                }
+
+                Hoek.assert(exception.message === 'Expected [Error: kaboom] to be an error with specified message', exception);
+                done();
+            });
+
+            it('validates assertion (type)', (done) => {
+
+                let exception = false;
+                try {
+                    Code.expect(error).to.be.an.error(Error);
+                }
+                catch (err) {
+                    exception = err;
+                }
+
+                Hoek.assert(!exception, exception);
+                done();
+            });
+
+            it('invalidates assertion (known type)', (done) => {
+
+                const Custom = function () { };
+
+                let exception = false;
+                try {
+                    Code.expect(new Custom()).to.be.an.error(Error);
+                }
+                catch (err) {
+                    exception = err;
+                }
+
+                Hoek.assert(exception.message === 'Expected {} to be an error with Error type', exception);
+                done();
+            });
+
+            it('invalidates assertion (anonymous type)', (done) => {
+
+                const Custom = function () { };
+                Hoek.inherits(Custom, Error);
+
+                let exception = false;
+                try {
+                    Code.expect(error).to.be.an.error(Custom);
+                }
+                catch (err) {
+                    exception = err;
+                }
+
+                Hoek.assert(exception.message === 'Expected [Error: kaboom] to be an error with provided type', exception);
+                done();
+            });
+
+            it('validates assertion (type and message)', (done) => {
+
+                let exception = false;
+                try {
+                    Code.expect(error).to.be.an.error(Error, 'kaboom');
+                }
+                catch (err) {
+                    exception = err;
+                }
+
+                Hoek.assert(!exception, exception);
+                done();
+            });
+        });
+
         describe('function()', () => {
 
             it('validates correct type', (done) => {


### PR DESCRIPTION
Mostly ripoff of the throw code with small adjustments in the tests because I considered not passing a type should still check whether that's an error type or not, I'd argue the throw logic is wrong on this side.