### PR TITLE
Invalidate array of objects with only a partial object value

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -198,6 +198,7 @@ internals.addMethod('error', function (/*type, message*/) {
 internals.include = function (value) {
 
     this._flags.deep = !this._flags.shallow;
+    this._flags.part = this._flags.hasOwnProperty('part') ? this._flags.part : false;
     return this.assert(Hoek.contain(this._ref, value, this._flags), 'include ' + internals.display(value));
 };
 

--- a/test/index.js
+++ b/test/index.js
@@ -1040,6 +1040,20 @@ describe('expect()', () => {
                 done();
             });
 
+            it('invalidates array with only a partial object value', (done) => {
+
+                let exception = false;
+                try {
+                    Code.expect([{ a: 1, b: 1 }]).to.include({ a: 1 });
+                }
+                catch (err) {
+                    exception = err;
+                }
+
+                Hoek.assert(exception.message === 'Expected [ { a: 1, b: 1 } ] to include { a: 1 }', exception);
+                done();
+            });
+
             it('invalidates arrays (shallow)', (done) => {
 
                 let exception = false;


### PR DESCRIPTION
It might be an issue with Hoek, though it is possible that the default value for `part` flag is true in `Hoek.contain`