### PR TITLE
Enhancement: Added validation to `include`

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -197,6 +197,8 @@ internals.addMethod('error', function (/*type, message*/) {
 
 internals.include = function (value) {
 
+    internals.assert(this, arguments.length === 1, 'Can only assert include with a single parameter');
+
     this._flags.deep = !this._flags.shallow;
     this._flags.part = this._flags.hasOwnProperty('part') ? this._flags.part : false;
     return this.assert(Hoek.contain(this._ref, value, this._flags), 'include ' + internals.display(value));

--- a/test/index.js
+++ b/test/index.js
@@ -1125,48 +1125,43 @@ describe('expect()', () => {
                 done();
             });
 
-            const tests = [
-                { name: 'no', act: () => Code.expect('abc').to.include() },
-                { name: 'two', act: () => Code.expect('abc').to.include('a', 'b') },
-                { name: 'three', act: () => Code.expect('abc').to.include('a', 'b', 'c') }
-            ];
-            for (const test of tests) {
+            it('asserts called with only one argument', (done) => {
 
-                it(`assertion fails when called with ${test.name} arguments`, (done) => {
-
+                {
                     let exception = false;
                     try {
-                        test.act();
+                        Code.expect('abc').to.include();
                     }
                     catch (err) {
                         exception = err;
                     }
                     Hoek.assert(exception.message === 'Can only assert include with a single parameter', exception);
-                    done();
-                });
-
-            }
-
-            it('asserts called with only one argument', (done) => {
-
-                let exception = false;
-                try {
-                    Code.expect('abc').to.include();
                 }
-                catch (err) {
-                    exception = err;
+
+                {
+                    let exception = false;
+                    try {
+                        Code.expect('abc').to.include('a');
+                    }
+                    catch (err) {
+                        exception = err;
+                    }
+
+                    Hoek.assert(exception === false, exception);
                 }
-                Hoek.assert(exception.message === 'Can only assert include with a single parameter', exception);
 
-                // let exception = false;
-                // try {
-                //     Code.expect('abc').to.include('a', 'b');
-                // }
-                // catch (err) {
-                //     exception = err;
-                // }
+                {
+                    let exception = false;
+                    try {
+                        Code.expect('abc').to.include('a', 'b');
+                    }
+                    catch (err) {
+                        exception = err;
+                    }
 
-                // Hoek.assert(exception.message === 'Can only assert include with a single parameter', exception);
+                    Hoek.assert(exception.message === 'Can only assert include with a single parameter', exception);
+                }
+
                 done();
             });
 

--- a/test/index.js
+++ b/test/index.js
@@ -1124,6 +1124,29 @@ describe('expect()', () => {
                 Hoek.assert(!exception, exception);
                 done();
             });
+
+            it('asserts called with only one argument', (done) => {
+
+                let exception0 = false;
+                try {
+                    Code.expect('abc').to.include();
+                }
+                catch (err) {
+                    exception0 = err;
+                }
+                let exception2 = false;
+                try {
+                    Code.expect('abc').to.include('a', 'b');
+                }
+                catch (err) {
+                    exception2 = err;
+                }
+
+                Hoek.assert(exception0.message === 'Can only assert include with a single parameter', exception0);
+                Hoek.assert(exception2.message === 'Can only assert include with a single parameter', exception2);
+                done();
+            });
+
         });
 
         describe('endWith()', () => {
@@ -2297,7 +2320,8 @@ describe('incomplete()', () => {
 
         const a = Code.expect(1).to;
         Code.expect(2).to.equal(2);
-        Hoek.assert(Code.incomplete().length === 1);
+        const actual = Code.incomplete();
+        Hoek.assert(actual.length === 1, actual);
         a.equal(1);
         Hoek.assert(!Code.incomplete());
         done();

--- a/test/index.js
+++ b/test/index.js
@@ -1141,18 +1141,6 @@ describe('expect()', () => {
                 {
                     let exception = false;
                     try {
-                        Code.expect('abc').to.include('a');
-                    }
-                    catch (err) {
-                        exception = err;
-                    }
-
-                    Hoek.assert(exception === false, exception);
-                }
-
-                {
-                    let exception = false;
-                    try {
                         Code.expect('abc').to.include('a', 'b');
                     }
                     catch (err) {

--- a/test/index.js
+++ b/test/index.js
@@ -1125,25 +1125,48 @@ describe('expect()', () => {
                 done();
             });
 
+            const tests = [
+                { name: 'no', act: () => Code.expect('abc').to.include() },
+                { name: 'two', act: () => Code.expect('abc').to.include('a', 'b') },
+                { name: 'three', act: () => Code.expect('abc').to.include('a', 'b', 'c') }
+            ];
+            for (const test of tests) {
+
+                it(`assertion fails when called with ${test.name} arguments`, (done) => {
+
+                    let exception = false;
+                    try {
+                        test.act();
+                    }
+                    catch (err) {
+                        exception = err;
+                    }
+                    Hoek.assert(exception.message === 'Can only assert include with a single parameter', exception);
+                    done();
+                });
+
+            }
+
             it('asserts called with only one argument', (done) => {
 
-                let exception0 = false;
+                let exception = false;
                 try {
                     Code.expect('abc').to.include();
                 }
                 catch (err) {
-                    exception0 = err;
+                    exception = err;
                 }
-                let exception2 = false;
-                try {
-                    Code.expect('abc').to.include('a', 'b');
-                }
-                catch (err) {
-                    exception2 = err;
-                }
+                Hoek.assert(exception.message === 'Can only assert include with a single parameter', exception);
 
-                Hoek.assert(exception0.message === 'Can only assert include with a single parameter', exception0);
-                Hoek.assert(exception2.message === 'Can only assert include with a single parameter', exception2);
+                // let exception = false;
+                // try {
+                //     Code.expect('abc').to.include('a', 'b');
+                // }
+                // catch (err) {
+                //     exception = err;
+                // }
+
+                // Hoek.assert(exception.message === 'Can only assert include with a single parameter', exception);
                 done();
             });
 
@@ -2320,8 +2343,7 @@ describe('incomplete()', () => {
 
         const a = Code.expect(1).to;
         Code.expect(2).to.equal(2);
-        const actual = Code.incomplete();
-        Hoek.assert(actual.length === 1, actual);
+        Hoek.assert(Code.incomplete().length === 1);
         a.equal(1);
         Hoek.assert(!Code.incomplete());
         done();


### PR DESCRIPTION
Added an extra assertion to check that the `include` expectation is always
called with just one argument.

Fixes: #83