### PR TITLE
Ability to match on a non-specific array item (#67)

### DIFF
--- a/API.md
+++ b/API.md
@@ -88,11 +88,14 @@ expect(6).to.be.in.range(5, 6);
 ### Flags
 
 The following words toggle a status flag for the current assertion:
+
 - `not` - inverses the expected result of any assertion.
 - `once` - requires that inclusion matches appear only once in the provided value. Used by `include()`.
 - `only` - requires that only the provided elements appear in the provided value. Used by `include()`.
 - `part` - allows a partial match when asserting inclusion. Used by `include()`. Defaults to `false`.
-- `shallow` - performs a comparison using strict equality (`===`). Code defaults to deep comparison. Used by `equal()` and `include()`.
+- `shallow` - code defaults to deep comparison
+    - used by `equal()` and `include()` to performs a comparison using strict equality (`===`).
+    - Used by `match()` to perform a regular expression match on the stringified version of an array.
 
 ```js
 const Code = require('code');
@@ -568,11 +571,15 @@ Aliases: `matches()`
 Asserts that the reference value is a string matching the provided regular expression where:
 - `regex` - the regular expression to match.
 
+If the assertion is deep and the reference value is an array then it will try and match on an item in the array otherwise it will stringify the array (`.toString()`).
+
 ```js
 const Code = require('code');
 const expect = Code.expect;
 
 expect('a5').to.match(/\w\d/);
+expect(['hello', 'hi']).to.match(/^hi$/);
+expect(['hello', 'hi']).to.shallow.match(/hello,hi/);
 ```
 
 #### `satisfy(validator)`

--- a/lib/index.js
+++ b/lib/index.js
@@ -342,6 +342,10 @@ internals.addMethod(['instanceof', 'instanceOf'], internals.instanceof);
 
 internals.match = function (regex) {
 
+    if (Array.isArray(this._ref) && !this._flags.shallow) {
+        return this.assert(this._ref.some((currentValue) => regex.exec(currentValue)), 'match ' + regex);
+    }
+
     return this.assert(regex.exec(this._ref), 'match ' + regex);
 };
 

--- a/test/index.js
+++ b/test/index.js
@@ -2011,6 +2011,77 @@ describe('expect()', () => {
                 Hoek.assert(exception.message === 'Expected \'a4x\' to match /\\w\\dy/', exception);
                 done();
             });
+
+            it('validates assertion deep inside an array', (done) => {
+
+                let exception = false;
+                const test = ['hello', 'hi'];
+                try {
+                    Code.expect(test).to.match(/hi/);
+                    Code.expect(test).to.match(/^hi/);
+                    Code.expect(test).to.match(/^hi$/);
+                    Code.expect(test).to.match(/^hello$/);
+                    Code.expect(test).to.match(/^Hello$/i);
+                    Code.expect(test).to.match(/ell/);
+                    Code.expect(test).to.match(/h/);
+                }
+                catch (err) {
+                    exception = err;
+                }
+
+                Hoek.assert(!exception, exception);
+                done();
+            });
+
+            it('invalidates assertion deep inside an array', (done) => {
+
+                let exception = false;
+                const test = ['hello', 'hi'];
+                try {
+                    Code.expect(test).to.not.match(/^Hello$/);
+                    Code.expect(test).to.not.match(/loh/);
+                    Code.expect(test).to.not.match(/lo,h/);
+                    Code.expect(test).to.not.match(new RegExp(test.toString()));
+                }
+                catch (err) {
+                    exception = err;
+                }
+
+                Hoek.assert(!exception, exception);
+                done();
+            });
+
+            it('validates shallow assertion inside an array', (done) => {
+
+                let exception = false;
+                const test = ['hello', 'hi'];
+                try {
+                    Code.expect(test).to.shallow.match(/hi/);
+                    Code.expect(test).to.shallow.match(new RegExp(test.toString()));
+                }
+                catch (err) {
+                    exception = err;
+                }
+
+                Hoek.assert(!exception, exception);
+                done();
+            });
+
+            it('invalidates shallow assertion inside an array', (done) => {
+
+                let exception = false;
+                const test = ['hello', 'hi'];
+                try {
+                    Code.expect(test).to.not.shallow.match(/^hi$/);
+                    Code.expect(test).to.not.shallow.match(/^hi/);
+                }
+                catch (err) {
+                    exception = err;
+                }
+
+                Hoek.assert(!exception, exception);
+                done();
+            });
         });
 
         describe('satisfy()', () => {


### PR DESCRIPTION
Added code, tests and documentation to allow a deep match on a
non-specific array item. This is a breaking change as it affects the
way that a match is performed on an array.

**Example**

Previous behaviour

```js
Code.expect(['hello', 'hi']).to.match(/hello,hi/);
Code.expect(['hello', 'hi']).to.not.match(/^hi/);
```

New behaviour

```js
Code.expect(['hello', 'hi']).to.not.match(/hello,hi/);
Code.expect(['hello', 'hi']).to.match(/^hi$/);
Code.expect(['hello', 'hi']).to.shallow.match(/hello,hi/);
Code.expect(['hello', 'hi']).to.not.shallow.match(/^hi/);
```

Fixes: #67
Version bump: Major