### PR TITLE
Reference value NaN assertion.

### DIFF
--- a/API.md
+++ b/API.md
@@ -304,7 +304,7 @@ expect(undefined).to.be.undefined();
 
 ##### `NaN()`
 
-Asserts that the reference value is NaN.
+Asserts that the reference value is `NaN`.
 
 ```js
 const Code = require('code');

--- a/API.md
+++ b/API.md
@@ -25,6 +25,7 @@
       - [`false()`](#false)
       - [`null()`](#null)
       - [`undefined()`](#undefined)
+      - [`NaN()`](#NaN)
     - [`include(values)`](#includevalues)
     - [`startWith(value)`](#startwithvalue)
     - [`endWith(value)`](#endwithvalue)
@@ -299,6 +300,17 @@ const Code = require('code');
 const expect = Code.expect;
 
 expect(undefined).to.be.undefined();
+```
+
+##### `NaN()`
+
+Asserts that the reference value is NaN.
+
+```js
+const Code = require('code');
+const expect = Code.expect;
+
+expect(NaN).to.be.NaN();
 ```
 
 #### `include(values)`

--- a/lib/index.js
+++ b/lib/index.js
@@ -195,6 +195,12 @@ internals.addMethod('error', function (/*type, message*/) {
 });
 
 
+internals.addMethod('NaN', function () {
+
+    return this.assert(isNaN(this._ref), 'be NaN');
+});
+
+
 internals.include = function (value) {
 
     internals.assert(this, arguments.length === 1, 'Can only assert include with a single parameter');

--- a/lib/index.js
+++ b/lib/index.js
@@ -197,7 +197,7 @@ internals.addMethod('error', function (/*type, message*/) {
 
 internals.addMethod('NaN', function () {
 
-    return this.assert(isNaN(this._ref), 'be NaN');
+    return this.assert(Number.isNaN(this._ref), 'be NaN');
 });
 
 

--- a/test/index.js
+++ b/test/index.js
@@ -1026,6 +1026,15 @@ describe('expect()', () => {
                 Hoek.assert(exception.message === 'Expected 1 to be NaN', exception);
                 done();
             });
+
+            it('invalidates incorrect types', (done) => {
+
+                Code.expect(1).not.to.be.NaN();
+                Code.expect('foo').not.to.be.NaN();
+                Code.expect({}).not.to.be.NaN();
+                Code.expect([]).not.to.be.NaN();
+                done();
+            });
         });
 
         describe('include()', () => {

--- a/test/index.js
+++ b/test/index.js
@@ -997,6 +997,37 @@ describe('expect()', () => {
             });
         });
 
+        describe('NaN()', () => {
+
+            it('validates correct type', (done) => {
+
+                let exception = false;
+                try {
+                    Code.expect(NaN).to.be.NaN();
+                }
+                catch (err) {
+                    exception = err;
+                }
+
+                Hoek.assert(!exception, exception);
+                done();
+            });
+
+            it('invalidates incorrect type', (done) => {
+
+                let exception = false;
+                try {
+                    Code.expect(1).to.be.NaN();
+                }
+                catch (err) {
+                    exception = err;
+                }
+
+                Hoek.assert(exception.message === 'Expected 1 to be NaN', exception);
+                done();
+            });
+        });
+
         describe('include()', () => {
 
             it('validates strings', (done) => {


### PR DESCRIPTION
To check whether the reference value is NaN or not.

For Example:

```
expect(NaN).to.be.NaN();
expect(1).not.to.be.NaN();
```