### PR TITLE
print expected value on equals assertion

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -275,7 +275,7 @@ internals.equal = function (value, options) {
     const compare = this._flags.shallow ? (a, b) => a === b
                                         : (a, b) => Hoek.deepEqual(a, b, settings);
 
-    return this.assert(compare(this._ref, value), `equal specified value: ${JSON.stringify(value)}`, this._ref, value);
+    return this.assert(compare(this._ref, value), `equal specified value: ${NodeUtil.inspect(value)}`, this._ref, value);
 };
 
 internals.addMethod(['equal', 'equals'], internals.equal);

--- a/lib/index.js
+++ b/lib/index.js
@@ -275,7 +275,7 @@ internals.equal = function (value, options) {
     const compare = this._flags.shallow ? (a, b) => a === b
                                         : (a, b) => Hoek.deepEqual(a, b, settings);
 
-    return this.assert(compare(this._ref, value), 'equal specified value', this._ref, value);
+    return this.assert(compare(this._ref, value), `equal specified value: ${JSON.stringify(value)}`, this._ref, value);
 };
 
 internals.addMethod(['equal', 'equals'], internals.equal);

--- a/test/index.js
+++ b/test/index.js
@@ -1573,7 +1573,7 @@ describe('expect()', () => {
                     exception = err;
                 }
 
-                Hoek.assert(exception.message === 'Expected { foo: 1 } to equal specified value: {"foo":2}', exception);
+                Hoek.assert(exception.message === 'Expected { foo: 1 } to equal specified value: { foo: 2 }', exception);
                 done();
             });
 
@@ -1605,7 +1605,7 @@ describe('expect()', () => {
                     exception = err;
                 }
 
-                Hoek.assert(exception.message === 'Expected [ \'a\' ] to equal specified value: ["a"]', exception);
+                Hoek.assert(exception.message === 'Expected [ \'a\' ] to equal specified value: [ \'a\' ]', exception);
                 done();
             });
 
@@ -1619,7 +1619,7 @@ describe('expect()', () => {
                     exception = err;
                 }
 
-                Hoek.assert(exception.message === 'Expected \'test\' to equal specified value: "junk"', exception);
+                Hoek.assert(exception.message === 'Expected \'test\' to equal specified value: \'junk\'', exception);
                 done();
             });
         });

--- a/test/index.js
+++ b/test/index.js
@@ -349,7 +349,7 @@ describe('expect()', () => {
         }
 
         Code.settings.comparePrototypes = origPrototype;
-        Hoek.assert(exception.message === 'Expected {} to equal specified value', exception);
+        Hoek.assert(exception.message === 'Expected {} to equal specified value: {}', exception);
         done();
     });
 
@@ -1573,7 +1573,7 @@ describe('expect()', () => {
                     exception = err;
                 }
 
-                Hoek.assert(exception.message === 'Expected { foo: 1 } to equal specified value', exception);
+                Hoek.assert(exception.message === 'Expected { foo: 1 } to equal specified value: {"foo":2}', exception);
                 done();
             });
 
@@ -1605,7 +1605,21 @@ describe('expect()', () => {
                     exception = err;
                 }
 
-                Hoek.assert(exception.message === 'Expected [ \'a\' ] to equal specified value', exception);
+                Hoek.assert(exception.message === 'Expected [ \'a\' ] to equal specified value: ["a"]', exception);
+                done();
+            });
+
+            it('prints the specified value', (done) => {
+
+                let exception = false;
+                try {
+                    Code.expect('test').to.equal('junk');
+                }
+                catch (err) {
+                    exception = err;
+                }
+
+                Hoek.assert(exception.message === 'Expected \'test\' to equal specified value: "junk"', exception);
                 done();
             });
         });


### PR DESCRIPTION
open to suggestions on other ways of printing both the actual and expected value on a failed equals assertion, this is a shot in the dark