### PR TITLE
Use JSDoc comments

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -23,6 +23,11 @@ exports.settings = {
 };
 
 
+/**
+ * @param {*} value
+ * @param {string} prefix
+ * @returns {Object}
+ */
 exports.expect = function (value, prefix) {
 
     const at = exports.thrownAt();
@@ -33,12 +38,18 @@ exports.expect = function (value, prefix) {
 };
 
 
+/**
+ * @param {string} message
+ */
 exports.fail = function (message) {
 
     throw new Error(message);
 };
 
 
+/**
+ * @returns {Object|null}
+ */
 exports.incomplete = function () {
 
     const locations = Object.keys(internals.locations);
@@ -46,12 +57,21 @@ exports.incomplete = function () {
 };
 
 
+/**
+ * @returns {number}
+ */
 exports.count = function () {
 
     return internals.count;
 };
 
 
+/**
+ * @param {*} ref
+ * @param {string} prefix
+ * @param {string} location
+ * @returns {void}
+ */
 internals.Assertion = function (ref, prefix, location) {
 
     this._ref = ref;
@@ -61,12 +81,23 @@ internals.Assertion = function (ref, prefix, location) {
 };
 
 
+/**
+ * @param {string} line
+ * @returns {boolean}
+ */
 internals.filterLocal = function (line) {
 
     return line.indexOf(__dirname) === -1;
 };
 
 
+/**
+ * @param {*} result
+ * @param {string} verb
+ * @param {Object} actual
+ * @param {Object} expected
+ * @returns {Object|void}
+ */
 internals.Assertion.prototype.assert = function (result, verb, actual, expected) {
 
     delete internals.locations[this._location];
@@ -141,7 +172,11 @@ internals.grammar.forEach((word) => {
     });
 });
 
-
+/**
+ * @param {Array<string>} names
+ * @param {Object} fn
+ * @returns {void}
+ */
 internals.addMethod = function (names, fn) {
 
     const method = function (name) {
@@ -166,6 +201,9 @@ internals.addMethod = function (names, fn) {
     internals.addMethod(word, method);
 });
 
+/**
+ * @returns {void}
+ */
 internals.addMethod('error', function (/*type, message*/) {
 
     const type = arguments.length && typeof arguments[0] !== 'string' && !(arguments[0] instanceof RegExp) ? arguments[0] : Error;
@@ -195,7 +233,9 @@ internals.addMethod('error', function (/*type, message*/) {
     internals.addMethod(name, method);
 });
 
-
+/**
+ * @returns {Object}
+ */
 internals.nan = function () {
 
     return this.assert(Number.isNaN(this._ref), 'be NaN');
@@ -204,6 +244,10 @@ internals.nan = function () {
 internals.addMethod('NaN', internals.nan);
 
 
+/**
+ * @param {*} value
+ * @returns {Object}
+ */
 internals.include = function (value) {
 
     internals.assert(this, arguments.length === 1, 'Can only assert include with a single parameter');
@@ -216,6 +260,10 @@ internals.include = function (value) {
 internals.addMethod(['include', 'includes', 'contain', 'contains'], internals.include);
 
 
+/**
+ * @param {*} value
+ * @returns {Object}
+ */
 internals.endWith = function (value) {
 
     internals.assert(this, typeof this._ref === 'string' && typeof value === 'string', 'Can only assert endsWith on a string, with a string');
@@ -227,6 +275,10 @@ internals.endWith = function (value) {
 internals.addMethod(['endWith', 'endsWith'], internals.endWith);
 
 
+/**
+ * @param {*} value
+ * @returns {Object}
+ */
 internals.startWith = function (value) {
 
     internals.assert(this, typeof this._ref === 'string' && typeof value === 'string', 'Can only assert startsWith on a string, with a string');
@@ -237,7 +289,9 @@ internals.startWith = function (value) {
 
 internals.addMethod(['startWith', 'startsWith'], internals.startWith);
 
-
+/**
+ * @returns {Object}
+ */
 internals.exist = function () {
 
     return this.assert(this._ref !== null && this._ref !== undefined, 'exist');
@@ -245,7 +299,9 @@ internals.exist = function () {
 
 internals.addMethod(['exist', 'exists'], internals.exist);
 
-
+/**
+ * @returns {Object}
+ */
 internals.empty = function () {
 
     internals.assert(this, typeof this._ref === 'object' || typeof this._ref === 'string', 'Can only assert empty on object, array or string');
@@ -257,6 +313,10 @@ internals.empty = function () {
 internals.addMethod('empty', internals.empty);
 
 
+/**
+ * @param {number} size
+ * @returns {Object}
+ */
 internals.length = function (size) {
 
     internals.assert(this, (typeof this._ref === 'object' && this._ref !== null) || typeof this._ref === 'string', 'Can only assert length on object, array or string');
@@ -268,6 +328,11 @@ internals.length = function (size) {
 internals.addMethod('length', internals.length);
 
 
+/**
+ * @param {*} value
+ * @param {Object} options
+ * @returns {Object}
+ */
 internals.equal = function (value, options) {
 
     options = options || {};
@@ -282,6 +347,10 @@ internals.equal = function (value, options) {
 internals.addMethod(['equal', 'equals'], internals.equal);
 
 
+/**
+ * @param {*} value
+ * @returns {Object}
+ */
 internals.above = function (value) {
 
     return this.assert(this._ref > value, 'be above ' + value);
@@ -290,6 +359,10 @@ internals.above = function (value) {
 internals.addMethod(['above', 'greaterThan'], internals.above);
 
 
+/**
+ * @param {*} value
+ * @returns {Object}
+ */
 internals.least = function (value) {
 
     return this.assert(this._ref >= value, 'be at least ' + value);
@@ -298,6 +371,10 @@ internals.least = function (value) {
 internals.addMethod(['least', 'min'], internals.least);
 
 
+/**
+ * @param {*} value
+ * @returns {Object}
+ */
 internals.below = function (value) {
 
     return this.assert(this._ref < value, 'be below ' + value);
@@ -306,6 +383,10 @@ internals.below = function (value) {
 internals.addMethod(['below', 'lessThan'], internals.below);
 
 
+/**
+ * @param {*} value
+ * @returns {Object}
+ */
 internals.most = function (value) {
 
     return this.assert(this._ref <= value, 'be at most ' + value);
@@ -314,6 +395,11 @@ internals.most = function (value) {
 internals.addMethod(['most', 'max'], internals.most);
 
 
+/**
+ * @param {number} from
+ * @param {number} to
+ * @returns {Object}
+ */
 internals.within = function (from, to) {
 
     return this.assert(this._ref >= from && this._ref <= to, 'be within ' + from + '..' + to);
@@ -322,6 +408,11 @@ internals.within = function (from, to) {
 internals.addMethod(['within', 'range'], internals.within);
 
 
+/**
+ * @param {number} from
+ * @param {number} to
+ * @returns {Object}
+ */
 internals.between = function (from, to) {
 
     return this.assert(this._ref > from && this._ref < to, 'be between ' + from + '..' + to);
@@ -330,6 +421,11 @@ internals.between = function (from, to) {
 internals.addMethod('between', internals.between);
 
 
+/**
+ * @param {number} value
+ * @param {number} delta
+ * @returns {Object}
+ */
 internals.above = function (value, delta) {
 
     internals.assert(this, internals.type(this._ref) === 'number', 'Can only assert about on numbers');
@@ -341,6 +437,10 @@ internals.above = function (value, delta) {
 internals.addMethod('about', internals.above);
 
 
+/**
+ * @param {Object} type
+ * @returns {Object}
+ */
 internals.instanceof = function (type) {
 
     return this.assert(this._ref instanceof type, 'be an instance of ' + (type.name || 'provided type'));
@@ -349,6 +449,10 @@ internals.instanceof = function (type) {
 internals.addMethod(['instanceof', 'instanceOf'], internals.instanceof);
 
 
+/**
+ * @param {Object} regex
+ * @returns {Object}
+ */
 internals.match = function (regex) {
 
     return this.assert(regex.exec(this._ref), 'match ' + regex);
@@ -357,6 +461,10 @@ internals.match = function (regex) {
 internals.addMethod(['match', 'matches'], internals.match);
 
 
+/**
+ * @param {Object} validator
+ * @returns {Object}
+ */
 internals.satisfy = function (validator) {
 
     return this.assert(validator(this._ref), 'satisfy rule');
@@ -364,7 +472,9 @@ internals.satisfy = function (validator) {
 
 internals.addMethod(['satisfy', 'satisfies'], internals.satisfy);
 
-
+/**
+ * @returns {Object}
+ */
 internals.throw = function (/* type, message */) {
 
     internals.assert(this, typeof this._ref === 'function', 'Can only assert throw on functions');
@@ -399,7 +509,9 @@ internals.throw = function (/* type, message */) {
 
 internals.addMethod(['throw', 'throws'], internals.throw);
 
-
+/**
+ * @returns {Object}
+ */
 internals.reject = async function (/* type, message */) {
 
     try {
@@ -450,12 +562,20 @@ internals.reject = async function (/* type, message */) {
 internals.addMethod(['reject', 'rejects'], internals.reject);
 
 
+/**
+ * @param {Object} promise
+ * @returns {boolean}
+ */
 internals.isPromise = function (promise) {
 
     return promise && typeof promise.then === 'function';
 };
 
 
+/**
+ * @param {*} value
+ * @returns {string}
+ */
 internals.display = function (value) {
 
     const string = value instanceof Error ? `[${value.toString()}]` : (internals.isPromise(value) ? '[Promise]' : NodeUtil.inspect(value));
@@ -489,6 +609,10 @@ internals.natives = {
 };
 
 
+/**
+ * @param {*} value
+ * @returns {string}
+ */
 internals.type = function (value) {
 
     if (value === null) {
@@ -515,7 +639,10 @@ internals.type = function (value) {
     return typeof value;
 };
 
-
+/**
+ * @param {Object} error
+ * @returns {Object|void}
+ */
 exports.thrownAt = function (error) {
 
     error = error || new Error();
@@ -530,6 +657,12 @@ exports.thrownAt = function (error) {
 };
 
 
+/**
+ * @param {Object} assertion
+ * @param {boolean} condition
+ * @param {string} error
+ * @returns {void}
+ */
 internals.assert = function (assertion, condition, error) {
 
     if (!condition) {

--- a/package.json
+++ b/package.json
@@ -17,13 +17,15 @@
     },
     "devDependencies": {
         "lab": "15.x.x",
-        "markdown-toc": "1.1.x"
+        "markdown-toc": "1.1.x",
+        "jsdoc": "3.x.x"
     },
     "scripts": {
         "test": "lab -v -t 100 -L",
         "test-cov-html": "lab -L -r html -o coverage.html",
         "toc": "node generate-api-toc.js",
-        "version": "npm run toc && git add API.md"
+        "version": "npm run toc && git add API.md",
+        "doc": "jsdoc ./lib/index.js --destination ./doc"
     },
     "license": "BSD-3-Clause"
 }


### PR DESCRIPTION
I think it's useful to have some JSDoc comments all over functions, so I added it. We can see directly the expected parameter types and what the function returns.

I also added the possibility to generate some documentation files with JSDoc module.