### PR TITLE
Add the correct thrownAt() location when using expect().to.reject()

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -29,7 +29,7 @@ exports.expect = function (value, prefix) {
     const location = at.filename + ':' + at.line + '.' + at.column;
     internals.locations[location] = true;
     ++internals.count;
-    return new internals.Assertion(value, prefix, location);
+    return new internals.Assertion(value, prefix, location, at);
 };
 
 
@@ -52,11 +52,12 @@ exports.count = function () {
 };
 
 
-internals.Assertion = function (ref, prefix, location) {
+internals.Assertion = function (ref, prefix, location, at) {
 
     this._ref = ref;
     this._prefix = prefix || '';
     this._location = location;
+    this._at = at;
     this._flags = {};
 };
 
@@ -112,7 +113,7 @@ internals.Assertion.prototype.assert = function (result, verb, actual, expected)
     Error.captureStackTrace(error, this.assert);
     error.actual = actual;
     error.expected = expected;
-    error.at = exports.thrownAt(error);
+    error.at = exports.thrownAt(error) || this._at;
     throw error;
 };
 
@@ -522,7 +523,7 @@ exports.thrownAt = function (error) {
     error = error || new Error();
     const stack = typeof error.stack === 'string' ? error.stack : '';
     const frame = stack.replace(error.toString(), '').split('\n').slice(1).filter(internals.filterLocal)[0] || '';
-    const at = frame.match(/^\s*at \(?(.+)\:(\d+)\:(\d+)\)?$/);
+    const at = frame.match(/^\s*at [^(]*\(?(.+)\:(\d+)\:(\d+)\)?$/);
     return Array.isArray(at) ? {
         filename: at[1],
         line: at[2],

--- a/test/index.js
+++ b/test/index.js
@@ -1218,6 +1218,7 @@ describe('expect()', () => {
 
                 Hoek.assert(exception.message === 'some message', exception);
                 Hoek.assert(exception.at.line !== Code.thrownAt(failed).line, 'Reports the wrong line number');
+                Hoek.assert(exception.at.filename === __filename, `expected ${exception.at.filename} to equal ${__filename}`);
             });
         });
 
@@ -2194,6 +2195,7 @@ describe('expect()', () => {
                 const Custom = function () { };
 
                 try {
+                    var expectedLineNumber = Number(new Error().stack.match(/:(\d+)/)[1]) + 1;
                     await Code.expect(Promise.reject(new Custom())).to.reject('kaboom');
                 }
                 catch (err) {
@@ -2201,6 +2203,8 @@ describe('expect()', () => {
                 }
 
                 Hoek.assert(exception.message === 'Expected [Promise] to reject with an error with specified message', exception);
+                Hoek.assert(Number(exception.at.line) === expectedLineNumber, `expected ${expectedLineNumber}, got ${exception.at.line}`);
+                Hoek.assert(exception.at.filename === __filename, `expected ${exception.at.filename} to equal ${__filename}`);
             });
 
             it('invalidates rejection (message)', async () => {


### PR DESCRIPTION
Hi,

when using `await expect().to.reject()` the location (filename, line, column) was incorrect:

```
Expected [Promise] to reject with an error with specified message

      at internals.Assertion.internals.reject (/node_modules/code/lib/index.js:434:22)
      at <anonymous>
      at process._tickCallback (internal/process/next_tick.js:188:7)
```
after this change it will point to the right location. I modified the tests to check for the filename and line number

another small issue was the regex, it started with `it (` instead of the filename, so you will have
`at it (/tests/test.js:10:1`
and now it should be
`at /tests/test.js:10:1`