### PR TITLE
Fixed unnamed functions error reporting

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -523,7 +523,7 @@ exports.thrownAt = function (error) {
     error = error || new Error();
     const stack = typeof error.stack === 'string' ? error.stack : '';
     const frame = stack.replace(error.toString(), '').split('\n').slice(1).filter(internals.filterLocal)[0] || '';
-    const at = frame.match(/^\s*at [^(]*\(?(.+)\:(\d+)\:(\d+)\)?$/);
+    const at = frame.match(/^\s*at [^(/]*\(?(.+)\:(\d+)\:(\d+)\)?$/);
     return Array.isArray(at) ? {
         filename: at[1],
         line: at[2],

--- a/test/index.js
+++ b/test/index.js
@@ -2424,4 +2424,25 @@ describe('thrownAt()', () => {
 
         Hoek.assert(at === undefined, 'Reports the wrong at information');
     });
+
+    it('handles error with unnamed functions', () => {
+
+        const test = (f) => f();
+
+        try {
+
+            // eslint-disable-next-line prefer-arrow-callback
+            test(function () {
+
+                Code.expect(true).to.be.false();
+            });
+
+            Code.fail('an error should have been thrown');
+        }
+        catch (ex) {
+
+            const at = Code.thrownAt(ex);
+            Hoek.assert(at.filename === __filename);
+        }
+    });
 });


### PR DESCRIPTION
I know arrow callbacks are preferred, but we're using generators sometimes and we came across this issue. 

Unnamed functions seem to be producing this as a test output as of late (I think it's because something in Node was changed somewhere). Tested using Node v11.1.0

> Failed tests:
> 
>   1) example/test x:
> 
>       Expected true to be false
> 
>       at s:635:38

When printing the 'at' we're seeing this;

> [ '    at ./code/test/index.js:2437:46',
>   's',
>   '2437',
>   '46',
>   index: 0,
>   input: '    at ./code/test/index.js:2437:46',
>   groups: undefined ]

As such, adding the slash to the regex fixes this issue.

