### PR TITLE
Fix reject(s) return type

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -514,8 +514,9 @@ declare namespace expect {
          *
          * @returns assertion chain object.
          */
-        reject(type: Function, message?: string | RegExp): Assertion<T>;
-        reject(message?: string | RegExp): Assertion<T>;
+        reject<E extends {}>(type: Function & { new(): E }, message?: string | RegExp): Promise<E >;
+        reject<E = unknown>(message: string | RegExp): Promise<E>;
+        reject(): Promise<null>;
 
         /**
          * Asserts that the Promise reference value rejects with an exception when called.
@@ -525,8 +526,9 @@ declare namespace expect {
          *
          * @returns assertion chain object.
          */
-        rejects(type: Function, message?: string | RegExp): Assertion<T>;
-        rejects(message?: string | RegExp): Assertion<T>;
+        rejects<E extends {}>(type: Function & { new(): E }, message?: string | RegExp): Promise<E>;
+        rejects<E = unknown>(message: string | RegExp): Promise<E>;
+        rejects(): Promise<null>;
 
         /**
          * Asserts that the reference value satisfies the provided validator function.

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -514,7 +514,7 @@ declare namespace expect {
          *
          * @returns assertion chain object.
          */
-        reject<E extends {}>(type: Function & { new(): E }, message?: string | RegExp): Promise<E >;
+        reject<E extends {}>(type: Function & { new(): E }, message?: string | RegExp): Promise<E>;
         reject<E = unknown>(message: string | RegExp): Promise<E>;
         reject(): Promise<null>;
 

--- a/test/index.ts
+++ b/test/index.ts
@@ -178,8 +178,9 @@ Code.expect(1).to.match(/^\d$/);
 Code.expect('x').to.satisfy(value => value === 'x');
 
 const rejection = Promise.reject(new Error('Oh no!'));
-await Code.expect(rejection).to.reject('Oh no!');
-await Code.expect(rejection).rejects('Oh no!');
+
+await expect.type<Promise<any>>(Code.expect(rejection).to.reject('Oh no!'));
+await expect.type<Promise<any>>(Code.expect(rejection).rejects('Oh no!'));
 
 class CustomError extends Error { }
 
@@ -191,5 +192,7 @@ const throws = () => {
 Code.expect(throws).to.throw(CustomError, 'Oh no!');
 
 const typedRejection = Promise.reject(new CustomError('Oh no!'));
-await Code.expect(typedRejection).to.reject(CustomError, 'Oh no!');
-await Code.expect(typedRejection).rejects(CustomError, 'Oh no!');
+await expect.type<Promise<CustomError>>(Code.expect(typedRejection).to.reject(CustomError, 'Oh no!'));
+await expect.type<Promise<CustomError>>(Code.expect(typedRejection).rejects(CustomError, 'Oh no!'));
+
+await expect.type<Promise<null>>(Code.expect(Promise.resolve(true)).to.not.reject());


### PR DESCRIPTION
Reject always returns a `Promise`.

The `reject(): Promise<null>` is for when it has been called with `.not`.

I considered restricting the `E` generic to be an `Error`, but decided against it since there is no such requirement in the code itself.