### PR TITLE
Don't narrow generic on type specific assertions

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -92,10 +92,10 @@ export namespace thrownAt {
  * 
  * @returns Assertion object.
  */
-export function expect<T>(value: T, prefix?: string):
-    T extends string ? expect.StringAssertion<T> :
-    T extends number | bigint ? expect.NumberAssertion<T> :
-    T extends Promise<any> ? expect.PromiseAssertion<T> :
+export function expect<T, TTest extends T>(value: T, prefix?: string):
+    TTest extends string ? expect.StringAssertion<T> :
+    TTest extends number | bigint ? expect.NumberAssertion<T> :
+    TTest extends Promise<any> ? expect.PromiseAssertion<T> :
     expect.Assertion<T>;
 
 declare namespace expect {

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -92,7 +92,7 @@ export namespace thrownAt {
  * 
  * @returns Assertion object.
  */
-export function expect<T, TTest extends T>(value: T, prefix?: string):
+export function expect<T, TTest extends T = T>(value: T, prefix?: string):
     TTest extends string ? expect.StringAssertion<T> :
     TTest extends number | bigint ? expect.NumberAssertion<T> :
     TTest extends Promise<any> ? expect.PromiseAssertion<T> :

--- a/test/index.ts
+++ b/test/index.ts
@@ -200,3 +200,9 @@ await expect.type<Promise<CustomError>>(Code.expect(typedRejection).to.reject(Cu
 await expect.type<Promise<CustomError>>(Code.expect(typedRejection).rejects(CustomError, 'Oh no!'));
 
 await expect.type<Promise<null>>(Code.expect(Promise.resolve(true)).to.not.reject());
+
+function foo(): number | undefined {
+    return 123;
+}
+
+Code.expect(foo()).to.equal(123);


### PR DESCRIPTION
This avoids resolving to `never` for ORed types like `number | string`. Closes #167.

This avoids narrowing the type that is forwarded to the type specific assertion by doing the conditional test on another `TTest` generic.