### PR TITLE
Fix throw() return value

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -413,8 +413,8 @@ declare namespace expect {
          *
          * @returns assertion chain object.
          */
-        throw(type: Class, message?: string | RegExp): this;
-        throw(message?: string | RegExp): this;
+        throw<E extends {}>(type: Class<E>, message?: string | RegExp): E;
+        throw<E = unknown>(message?: string | RegExp): E;
 
         /**
          * Asserts that the function reference value throws an exception when called.
@@ -424,8 +424,8 @@ declare namespace expect {
          *
          * @returns assertion chain object.
          */
-        throws(type: Class, message?: string | RegExp): this;
-        throws(message?: string | RegExp): this;
+        throws<E extends {}>(type: Class<E>, message?: string | RegExp): E;
+        throws<E = unknown>(message?: string | RegExp): E;
     }
 
     interface StringAssertion<T> extends Assertion<T> {

--- a/lib/index.js
+++ b/lib/index.js
@@ -421,7 +421,7 @@ internals.throw = function (...args /* type, message */) {
         return err;
     }
 
-    return this.assert(thrown, 'throw an error');
+    this.assert(thrown, 'throw an error');
 };
 
 internals.addMethod(['throw', 'throws'], internals.throw);

--- a/test/index.js
+++ b/test/index.js
@@ -262,7 +262,6 @@ describe('expect()', () => {
             Code.expect('abc').to.not.contain('d').and.to.contain('a');
             Code.expect('abc').to.not.contain('d').and.to.not.contain('e');
             Code.expect('abc').to.contain('a').and.to.not.contain('d').and.to.contain('c').to.not.contain('f');
-            Code.expect(() => { }).to.not.throw().and.to.be.a.function();
             Code.expect(10).to.not.be.about(8, 1).and.to.be.about(9, 1);
             Code.expect(10).to.be.about(9, 1).and.to.not.be.about(8, 1);
         }

--- a/test/index.ts
+++ b/test/index.ts
@@ -186,16 +186,33 @@ const rejection = Promise.reject(new Error('Oh no!'));
 await expect.type<Promise<any>>(Code.expect(rejection).to.reject('Oh no!'));
 await expect.type<Promise<any>>(Code.expect(rejection).rejects('Oh no!'));
 
-class CustomError extends Error { }
+class CustomError extends Error {
+    code: number;
+
+    constructor(message: string, code: number) {
+        super(message);
+        this.code = code;
+    }
+ }
 
 const throws = () => {
 
-    throw new CustomError('Oh no!');
+    throw new CustomError('Oh no!', 555);
 };
 
-Code.expect(throws).to.throw(CustomError, 'Oh no!');
+const thrownError1 = Code.expect(throws).to.throw(CustomError, 'Oh no!');
+expect.type<number>(thrownError1.code);
 
-const typedRejection = Promise.reject(new CustomError('Oh no!'));
+const thrownError2 = Code.expect(throws).to.throw<CustomError>('Oh no!');
+expect.type<number>(thrownError2.code);
+
+const thrownError3 = Code.expect(throws).throws(CustomError, 'Oh no!');
+expect.type<number>(thrownError3.code);
+
+const thrownError4 = Code.expect(throws).throws<CustomError>('Oh no!');
+expect.type<number>(thrownError4.code);
+
+const typedRejection = Promise.reject(new CustomError('Oh no!', 555));
 await expect.type<Promise<CustomError>>(Code.expect(typedRejection).to.reject(CustomError, 'Oh no!'));
 await expect.type<Promise<CustomError>>(Code.expect(typedRejection).rejects(CustomError, 'Oh no!'));
 


### PR DESCRIPTION
The `expect().to.throw()` assertion has an inconsistent return value that does not make sense. It is the result of adding the error as the return value when the assertion passes(and throws) so the error itself can be inspected. When this was added a while back, it was done incorrectly (well, to avoid a breaking change). The result is an api that doesn't make sense, especially when used in TypeScript (which currently doesn't even support it).

This breaking change is unlikely to impact many since the `and()` construct is rarely used with `throw()` and if it doesn't indicates a poorly written test.