### PR TITLE
Fix typings for throw() and reject()

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -101,7 +101,7 @@ export function expect<T, TTest extends T = T>(value: T, prefix?: string):
 
 declare namespace expect {
 
-    interface Assertion<T> {
+    interface Assertion<T, TTest extends T = T> {
 
         // Grammar
 
@@ -120,8 +120,8 @@ declare namespace expect {
         /**
          * Inverses the expected result of the assertion chain.
          */
-        not: T extends Function ? expect.Not_FunctionAssertion<T> :
-             T extends Promise<any> ? expect.Not_PromiseAssertion<T> :
+        not: TTest extends Function ? expect.Not_FunctionAssertion<T> :
+             TTest extends Promise<any> ? expect.Not_PromiseAssertion<T> :
              this;
 
         /**

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -84,13 +84,6 @@ export namespace thrownAt {
 }
 
 
-type TNarrowedAssertion<T, TTest extends T = T> =
-    TTest extends Function ? expect.FunctionAssertion<T> :
-    TTest extends string ? expect.StringAssertion<T> :
-    TTest extends number | bigint ? expect.NumberAssertion<T> :
-    TTest extends Promise<any> ? expect.PromiseAssertion<T> :
-    expect.Assertion<T>;
-
 /**
  * Declares an assertion chain.
  * 
@@ -99,11 +92,18 @@ type TNarrowedAssertion<T, TTest extends T = T> =
  * 
  * @returns Assertion object.
  */
-export function expect<T>(value: T, prefix?: string): TNarrowedAssertion<T>;
+export function expect<T>(value: T, prefix?: string): expect.Assertion<T>;
 
 declare namespace expect {
 
-    interface Assertion<T, TTest extends T = T> {
+    type Assertion<T, TTest extends T = T> =
+        TTest extends Function ? expect.FunctionAssertion<T> :
+        TTest extends string ? expect.StringAssertion<T> :
+        TTest extends number | bigint ? expect.NumberAssertion<T> :
+        TTest extends Promise<any> ? expect.PromiseAssertion<T> :
+        expect.BaseAssertion<T>;
+
+    interface BaseAssertion<T, TTest extends T = T> {
 
         // Grammar
 
@@ -154,35 +154,35 @@ declare namespace expect {
          * 
          * @returns assertion chain object.
          */
-        arguments(): TNarrowedAssertion<T>;
+        arguments(): Assertion<T>;
 
         /**
          * Asserts that the reference value is an Array.
          *
          * @returns assertion chain object.
          */
-        array(): TNarrowedAssertion<T>;
+        array(): Assertion<T>;
 
         /**
          * Asserts that the reference value is a boolean.
          *
          * @returns assertion chain object.
          */
-        boolean(): TNarrowedAssertion<T>;
+        boolean(): Assertion<T>;
 
         /**
          * Asserts that the reference value is a Buffer.
          *
          * @returns assertion chain object.
          */
-        buffer(): TNarrowedAssertion<T>;
+        buffer(): Assertion<T>;
 
         /**
          * Asserts that the reference value is a Date
          *
          * @returns assertion chain object.
          */
-        date(): TNarrowedAssertion<T>;
+        date(): Assertion<T>;
 
         /**
          * Asserts that the reference value is an error.
@@ -192,43 +192,43 @@ declare namespace expect {
          *
          * @returns assertion chain object.
          */
-        error(type: Class, message?: string | RegExp): TNarrowedAssertion<T>;
-        error(message?: string | RegExp): TNarrowedAssertion<T>;
+        error(type: Class, message?: string | RegExp): Assertion<T>;
+        error(message?: string | RegExp): Assertion<T>;
 
         /**
          * Asserts that the reference value is a function.
          *
          * @returns assertion chain object.
          */
-        function(): TNarrowedAssertion<T>;
+        function(): Assertion<T>;
 
         /**
          * Asserts that the reference value is a number.
          *
          * @returns assertion chain object.
          */
-        number(): TNarrowedAssertion<T>;
+        number(): Assertion<T>;
 
         /**
          * Asserts that the reference value is a RegExp.
          *
          * @returns assertion chain object.
          */
-        regexp(): TNarrowedAssertion<T>;
+        regexp(): Assertion<T>;
 
         /**
          * Asserts that the reference value is a string.
          *
          * @returns assertion chain object.
          */
-        string(): TNarrowedAssertion<T>;
+        string(): Assertion<T>;
 
         /**
          * Asserts that the reference value is an object (excluding array, buffer, or other native objects).
          *
          * @returns assertion chain object.
          */
-        object(): TNarrowedAssertion<T>;
+        object(): Assertion<T>;
 
 
         // Values
@@ -238,35 +238,35 @@ declare namespace expect {
          *
          * @returns assertion chain object.
          */
-        true(): TNarrowedAssertion<T>;
+        true(): Assertion<T>;
 
         /**
          * Asserts that the reference value is false.
          *
          * @returns assertion chain object.
          */
-        false(): TNarrowedAssertion<T>;
+        false(): Assertion<T>;
 
         /**
          * Asserts that the reference value is null.
          *
          * @returns assertion chain object.
          */
-        null(): TNarrowedAssertion<T>;
+        null(): Assertion<T>;
 
         /**
          * Asserts that the reference value is undefined.
          *
          * @returns assertion chain object.
          */
-        undefined(): TNarrowedAssertion<T>;
+        undefined(): Assertion<T>;
 
         /**
          * Asserts that the reference value is `NaN`.
          *
          * @returns assertion chain object.
          */
-        NaN(): TNarrowedAssertion<T>;
+        NaN(): Assertion<T>;
 
         // Tests
 
@@ -277,8 +277,8 @@ declare namespace expect {
          *
          * @returns assertion chain object.
          */
-        include(values: UnpackArray<Loosely<T> | Loosely<T>[]>): TNarrowedAssertion<T>;
-        include(values: string | string[]): TNarrowedAssertion<T>;
+        include(values: UnpackArray<Loosely<T> | Loosely<T>[]>): Assertion<T>;
+        include(values: string | string[]): Assertion<T>;
 
         /**
          * Asserts that the reference value (a string, array, or object) includes the provided values.
@@ -287,8 +287,8 @@ declare namespace expect {
          *
          * @returns assertion chain object.
          */
-        includes(values: UnpackArray<Loosely<T> | Loosely<T>[]>): TNarrowedAssertion<T>;
-        includes(values: string | string[]): TNarrowedAssertion<T>;
+        includes(values: UnpackArray<Loosely<T> | Loosely<T>[]>): Assertion<T>;
+        includes(values: string | string[]): Assertion<T>;
 
         /**
          * Asserts that the reference value (a string, array, or object) includes the provided values.
@@ -297,8 +297,8 @@ declare namespace expect {
          *
          * @returns assertion chain object.
          */
-        contain(values: UnpackArray<Loosely<T> | Loosely<T>[]>): TNarrowedAssertion<T>;
-        contain(values: string | string[]): TNarrowedAssertion<T>;
+        contain(values: UnpackArray<Loosely<T> | Loosely<T>[]>): Assertion<T>;
+        contain(values: string | string[]): Assertion<T>;
 
         /**
          * Asserts that the reference value (a string, array, or object) includes the provided values.
@@ -307,29 +307,29 @@ declare namespace expect {
          *
          * @returns assertion chain object.
          */
-        contains(values: UnpackArray<Loosely<T> | Loosely<T>[]>): TNarrowedAssertion<T>;
-        contains(values: string | string[]): TNarrowedAssertion<T>;
+        contains(values: UnpackArray<Loosely<T> | Loosely<T>[]>): Assertion<T>;
+        contains(values: string | string[]): Assertion<T>;
 
         /**
          * Asserts that the reference value exists (not null or undefined).
          *
          * @returns assertion chain object.
          */
-        exist(): TNarrowedAssertion<T>;
+        exist(): Assertion<T>;
 
         /**
          * Asserts that the reference value exists (not null or undefined).
          *
          * @returns assertion chain object.
          */
-        exists(): TNarrowedAssertion<T>;
+        exists(): Assertion<T>;
 
         /**
          * Asserts that the reference value has a length property equal to zero or is an object with no keys.
          *
          * @returns assertion chain object.
          */
-        empty(): TNarrowedAssertion<T>;
+        empty(): Assertion<T>;
 
         /**
          * Asserts that the reference value has a length property matching the provided size or an object with the specified number of keys.
@@ -338,7 +338,7 @@ declare namespace expect {
          *
          * @returns assertion chain object.
          */
-        length(size: T extends string | Buffer | object | any[] ? number : never): TNarrowedAssertion<T>;
+        length(size: T extends string | Buffer | object | any[] ? number : never): Assertion<T>;
 
         /**
          * Asserts that the reference value equals the provided value.
@@ -348,7 +348,7 @@ declare namespace expect {
          *
          * @returns assertion chain object.
          */
-        equal(value: T, options?: Hoek.deepEqual.Options): TNarrowedAssertion<T>;
+        equal(value: T, options?: Hoek.deepEqual.Options): Assertion<T>;
 
         /**
          * Asserts that the reference value equals the provided value.
@@ -358,21 +358,21 @@ declare namespace expect {
          *
          * @returns assertion chain object.
          */
-        equals(value: T, options?: Hoek.deepEqual.Options): TNarrowedAssertion<T>;
+        equals(value: T, options?: Hoek.deepEqual.Options): Assertion<T>;
 
         /**
          * Asserts that the reference value has the provided instanceof value.
          * 
          * @param type - the constructor function to be an instance of.
          */
-        instanceof(type: Class): TNarrowedAssertion<T>;
+        instanceof(type: Class): Assertion<T>;
 
         /**
          * Asserts that the reference value has the provided instanceof value.
          *
          * @param type - the constructor function to be an instance of.
          */
-        instanceOf(type: Class): TNarrowedAssertion<T>;
+        instanceOf(type: Class): Assertion<T>;
 
         /**
          * Asserts that the reference value's toString() representation matches the provided regular expression.
@@ -381,7 +381,7 @@ declare namespace expect {
          *
          * @returns assertion chain object.
          */
-        match(regex: RegExp): TNarrowedAssertion<T>;
+        match(regex: RegExp): Assertion<T>;
 
         /**
          * Asserts that the reference value's toString() representation matches the provided regular expression.
@@ -390,7 +390,7 @@ declare namespace expect {
          *
          * @returns assertion chain object.
          */
-        matches(regex: RegExp): TNarrowedAssertion<T>;
+        matches(regex: RegExp): Assertion<T>;
 
         /**
          * Asserts that the reference value satisfies the provided validator function.
@@ -399,7 +399,7 @@ declare namespace expect {
          *
          * @returns assertion chain object.
          */
-        satisfy(validator: (value: T) => boolean): TNarrowedAssertion<T>;
+        satisfy(validator: (value: T) => boolean): Assertion<T>;
 
         /**
          * Asserts that the reference value satisfies the provided validator function.
@@ -408,10 +408,10 @@ declare namespace expect {
          *
          * @returns assertion chain object.
          */
-        satisfies(validator: (value: T) => boolean): TNarrowedAssertion<T>;
+        satisfies(validator: (value: T) => boolean): Assertion<T>;
     }
 
-    interface FunctionAssertion<T> extends Assertion<T> {
+    interface FunctionAssertion<T> extends BaseAssertion<T> {
 
         /**
          * Asserts that the function reference value throws an exception when called.
@@ -436,26 +436,26 @@ declare namespace expect {
         throws<E = unknown>(message?: string | RegExp): E;
     }
 
-    interface Not_FunctionAssertion<T> extends Assertion<T> {
+    interface Not_FunctionAssertion<T> extends BaseAssertion<T> {
 
         /**
          * Asserts that the function reference value throws an exception when called.
          *
          * @returns assertion chain object.
          */
-        throw(): TNarrowedAssertion<T>;
-        throw(): TNarrowedAssertion<T>;
+        throw(): Assertion<T>;
+        throw(): Assertion<T>;
 
         /**
          * Asserts that the function reference value throws an exception when called.
          *
          * @returns assertion chain object.
          */
-        throws(): TNarrowedAssertion<T>;
-        throws(): TNarrowedAssertion<T>;
+        throws(): Assertion<T>;
+        throws(): Assertion<T>;
     }
 
-    interface StringAssertion<T> extends Assertion<T> {
+    interface StringAssertion<T> extends BaseAssertion<T> {
 
         /**
          * Asserts that the reference value (a string) starts with the provided value.
@@ -464,7 +464,7 @@ declare namespace expect {
          *
          * @returns assertion chain object.
          */
-        startWith(value: string): TNarrowedAssertion<T>;
+        startWith(value: string): Assertion<T>;
 
         /**
          * Asserts that the reference value (a string) starts with the provided value.
@@ -473,7 +473,7 @@ declare namespace expect {
          *
          * @returns assertion chain object.
          */
-        startsWith(value: string): TNarrowedAssertion<T>;
+        startsWith(value: string): Assertion<T>;
 
         /**
          * Asserts that the reference value (a string) ends with the provided value.
@@ -482,7 +482,7 @@ declare namespace expect {
          *
          * @returns assertion chain object.
          */
-        endWith(value: string): TNarrowedAssertion<T>;
+        endWith(value: string): Assertion<T>;
 
         /**
          * Asserts that the reference value (a string) ends with the provided value.
@@ -491,10 +491,10 @@ declare namespace expect {
          *
          * @returns assertion chain object.
          */
-        endsWith(value: string): TNarrowedAssertion<T>;
+        endsWith(value: string): Assertion<T>;
     }
 
-    interface NumberAssertion<T> extends Assertion<T> {
+    interface NumberAssertion<T> extends BaseAssertion<T> {
 
         /**
          * Asserts that the reference value is greater than (>) the provided value.
@@ -503,7 +503,7 @@ declare namespace expect {
          *
          * @returns assertion chain object.
          */
-        above(value: T): TNarrowedAssertion<T>;
+        above(value: T): Assertion<T>;
 
         /**
          * Asserts that the reference value is greater than (>) the provided value.
@@ -512,7 +512,7 @@ declare namespace expect {
          *
          * @returns assertion chain object.
          */
-        greaterThan(value: T): TNarrowedAssertion<T>;
+        greaterThan(value: T): Assertion<T>;
 
         /**
          * Asserts that the reference value is at least (>=) the provided value.
@@ -521,7 +521,7 @@ declare namespace expect {
          *
          * @returns assertion chain object.
          */
-        least(value: T): TNarrowedAssertion<T>;
+        least(value: T): Assertion<T>;
 
         /**
          * Asserts that the reference value is at least (>=) the provided value.
@@ -530,7 +530,7 @@ declare namespace expect {
          *
          * @returns assertion chain object.
          */
-        min(value: T): TNarrowedAssertion<T>;
+        min(value: T): Assertion<T>;
 
         /**
          * Asserts that the reference value is less than (<) the provided value.
@@ -539,7 +539,7 @@ declare namespace expect {
          *
          * @returns assertion chain object.
          */
-        below(value: T): TNarrowedAssertion<T>;
+        below(value: T): Assertion<T>;
 
         /**
          * Asserts that the reference value is less than (<) the provided value.
@@ -548,7 +548,7 @@ declare namespace expect {
          *
          * @returns assertion chain object.
          */
-        lessThan(value: T): TNarrowedAssertion<T>;
+        lessThan(value: T): Assertion<T>;
 
         /**
          * Asserts that the reference value is at most (<=) the provided value.
@@ -557,7 +557,7 @@ declare namespace expect {
          *
          * @returns assertion chain object.
          */
-        most(value: T): TNarrowedAssertion<T>;
+        most(value: T): Assertion<T>;
 
         /**
          * Asserts that the reference value is at most (<=) the provided value.
@@ -566,7 +566,7 @@ declare namespace expect {
          *
          * @returns assertion chain object.
          */
-        max(value: T): TNarrowedAssertion<T>;
+        max(value: T): Assertion<T>;
 
         /**
          * Asserts that the reference value is within (from <= value <= to) the provided values.
@@ -576,7 +576,7 @@ declare namespace expect {
          *
          * @returns assertion chain object.
          */
-        within(from: T, to: T): TNarrowedAssertion<T>;
+        within(from: T, to: T): Assertion<T>;
 
         /**
          * Asserts that the reference value is within (from <= value <= to) the provided values.
@@ -586,7 +586,7 @@ declare namespace expect {
          *
          * @returns assertion chain object.
          */
-        range(from: T, to: T): TNarrowedAssertion<T>;
+        range(from: T, to: T): Assertion<T>;
 
         /**
          * Asserts that the reference value is between but not equal (from < value < to) the provided values.
@@ -596,7 +596,7 @@ declare namespace expect {
          *
          * @returns assertion chain object.
          */
-        between(from: T, to: T): TNarrowedAssertion<T>;
+        between(from: T, to: T): Assertion<T>;
 
         /**
          * Asserts that the reference value is about the provided value within a delta margin of difference.
@@ -606,10 +606,10 @@ declare namespace expect {
          *
          * @returns assertion chain object.
          */
-        about(value: T extends number ? T : never, delta: T extends number ? T : never): TNarrowedAssertion<T>;
+        about(value: T extends number ? T : never, delta: T extends number ? T : never): Assertion<T>;
     }
 
-    interface PromiseAssertion<T> extends Assertion<T> {
+    interface PromiseAssertion<T> extends BaseAssertion<T> {
 
         /**
          * Asserts that the Promise reference value rejects with an exception when called.
@@ -634,7 +634,7 @@ declare namespace expect {
         rejects<E = unknown>(message?: string | RegExp): E;
     }
 
-    interface Not_PromiseAssertion<T> extends Assertion<T> {
+    interface Not_PromiseAssertion<T> extends BaseAssertion<T> {
 
         /**
          * Asserts that the Promise reference value rejects with an exception when called.

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -93,6 +93,7 @@ export namespace thrownAt {
  * @returns Assertion object.
  */
 export function expect<T, TTest extends T = T>(value: T, prefix?: string):
+    TTest extends Function ? expect.FunctionAssertion<T> :
     TTest extends string ? expect.StringAssertion<T> :
     TTest extends number | bigint ? expect.NumberAssertion<T> :
     TTest extends Promise<any> ? expect.PromiseAssertion<T> :
@@ -119,7 +120,9 @@ declare namespace expect {
         /**
          * Inverses the expected result of the assertion chain.
          */
-        not: this;
+        not: T extends Function ? expect.Not_FunctionAssertion<T> :
+             T extends Promise<any> ? expect.Not_PromiseAssertion<T> :
+             this;
 
         /**
          * Requires that inclusion matches appear only once in the provided value.
@@ -404,6 +407,9 @@ declare namespace expect {
          * @returns assertion chain object.
          */
         satisfies(validator: (value: T) => boolean): this;
+    }
+
+    interface FunctionAssertion<T> extends Assertion<T> {
 
         /**
          * Asserts that the function reference value throws an exception when called.
@@ -411,10 +417,10 @@ declare namespace expect {
          * @param type - constructor function the error must be an instance of.
          * @param message - string or regular expression the error message must match.
          *
-         * @returns assertion chain object.
+         * @returns thrown value.
          */
-        throw(type: Class, message?: string | RegExp): this;
-        throw(message?: string | RegExp): this;
+        throw<E extends {}>(type: Class<E>, message?: string | RegExp): E;
+        throw<E = unknown>(message?: string | RegExp): E;
 
         /**
          * Asserts that the function reference value throws an exception when called.
@@ -422,13 +428,33 @@ declare namespace expect {
          * @param type - constructor function the error must be an instance of.
          * @param message - string or regular expression the error message must match.
          *
+         * @returns thrown value.
+         */
+        throws<E extends {}>(type: Class<E>, message?: string | RegExp): E;
+        throws<E = unknown>(message?: string | RegExp): E;
+    }
+
+    interface Not_FunctionAssertion<T> extends Assertion<T> {
+
+        /**
+         * Asserts that the function reference value throws an exception when called.
+         *
          * @returns assertion chain object.
          */
-        throws(type: Class, message?: string | RegExp): this;
-        throws(message?: string | RegExp): this;
+        throw(): this;
+        throw(): this;
+
+        /**
+         * Asserts that the function reference value throws an exception when called.
+         *
+         * @returns assertion chain object.
+         */
+        throws(): this;
+        throws(): this;
     }
 
     interface StringAssertion<T> extends Assertion<T> {
+
         /**
          * Asserts that the reference value (a string) starts with the provided value.
          * 
@@ -589,11 +615,10 @@ declare namespace expect {
          * @param type - constructor function the error must be an instance of.
          * @param message - string or regular expression the error message must match.
          *
-         * @returns assertion chain object.
+         * @returns rejected value.
          */
-        reject<E extends {}>(type: Class<E>, message?: string | RegExp): Promise<E>;
-        reject<E = unknown>(message: string | RegExp): Promise<E>;
-        reject(): Promise<null>;
+        reject<E extends {}>(type: Class<E>, message?: string | RegExp): E;
+        reject<E = unknown>(message?: string | RegExp): E;
 
         /**
          * Asserts that the Promise reference value rejects with an exception when called.
@@ -601,10 +626,26 @@ declare namespace expect {
          * @param type - constructor function the error must be an instance of.
          * @param message - string or regular expression the error message must match.
          *
-         * @returns assertion chain object.
+         * @returns rejected value.
          */
-        rejects<E extends {}>(type: Class<E>, message?: string | RegExp): Promise<E>;
-        rejects<E = unknown>(message: string | RegExp): Promise<E>;
-        rejects(): Promise<null>;
+        rejects<E extends {}>(type: Class<E>, message?: string | RegExp): E;
+        rejects<E = unknown>(message?: string | RegExp): E;
+    }
+
+    interface Not_PromiseAssertion<T> extends Assertion<T> {
+
+        /**
+         * Asserts that the Promise reference value rejects with an exception when called.
+         *
+         * @returns null.
+         */
+        reject(): null;
+
+        /**
+         * Asserts that the Promise reference value rejects with an exception when called.
+         *
+         * @returns null.
+         */
+        rejects(): null;
     }
 }

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -84,6 +84,13 @@ export namespace thrownAt {
 }
 
 
+type TNarrowedAssertion<T, TTest extends T = T> =
+    TTest extends Function ? expect.FunctionAssertion<T> :
+    TTest extends string ? expect.StringAssertion<T> :
+    TTest extends number | bigint ? expect.NumberAssertion<T> :
+    TTest extends Promise<any> ? expect.PromiseAssertion<T> :
+    expect.Assertion<T>;
+
 /**
  * Declares an assertion chain.
  * 
@@ -92,12 +99,7 @@ export namespace thrownAt {
  * 
  * @returns Assertion object.
  */
-export function expect<T, TTest extends T = T>(value: T, prefix?: string):
-    TTest extends Function ? expect.FunctionAssertion<T> :
-    TTest extends string ? expect.StringAssertion<T> :
-    TTest extends number | bigint ? expect.NumberAssertion<T> :
-    TTest extends Promise<any> ? expect.PromiseAssertion<T> :
-    expect.Assertion<T>;
+export function expect<T>(value: T, prefix?: string): TNarrowedAssertion<T>;
 
 declare namespace expect {
 
@@ -152,35 +154,35 @@ declare namespace expect {
          * 
          * @returns assertion chain object.
          */
-        arguments(): this;
+        arguments(): TNarrowedAssertion<T>;
 
         /**
          * Asserts that the reference value is an Array.
          *
          * @returns assertion chain object.
          */
-        array(): this;
+        array(): TNarrowedAssertion<T>;
 
         /**
          * Asserts that the reference value is a boolean.
          *
          * @returns assertion chain object.
          */
-        boolean(): this;
+        boolean(): TNarrowedAssertion<T>;
 
         /**
          * Asserts that the reference value is a Buffer.
          *
          * @returns assertion chain object.
          */
-        buffer(): this;
+        buffer(): TNarrowedAssertion<T>;
 
         /**
          * Asserts that the reference value is a Date
          *
          * @returns assertion chain object.
          */
-        date(): this;
+        date(): TNarrowedAssertion<T>;
 
         /**
          * Asserts that the reference value is an error.
@@ -190,43 +192,43 @@ declare namespace expect {
          *
          * @returns assertion chain object.
          */
-        error(type: Class, message?: string | RegExp): this;
-        error(message?: string | RegExp): this;
+        error(type: Class, message?: string | RegExp): TNarrowedAssertion<T>;
+        error(message?: string | RegExp): TNarrowedAssertion<T>;
 
         /**
          * Asserts that the reference value is a function.
          *
          * @returns assertion chain object.
          */
-        function(): this;
+        function(): TNarrowedAssertion<T>;
 
         /**
          * Asserts that the reference value is a number.
          *
          * @returns assertion chain object.
          */
-        number(): this;
+        number(): TNarrowedAssertion<T>;
 
         /**
          * Asserts that the reference value is a RegExp.
          *
          * @returns assertion chain object.
          */
-        regexp(): this;
+        regexp(): TNarrowedAssertion<T>;
 
         /**
          * Asserts that the reference value is a string.
          *
          * @returns assertion chain object.
          */
-        string(): this;
+        string(): TNarrowedAssertion<T>;
 
         /**
          * Asserts that the reference value is an object (excluding array, buffer, or other native objects).
          *
          * @returns assertion chain object.
          */
-        object(): this;
+        object(): TNarrowedAssertion<T>;
 
 
         // Values
@@ -236,35 +238,35 @@ declare namespace expect {
          *
          * @returns assertion chain object.
          */
-        true(): this;
+        true(): TNarrowedAssertion<T>;
 
         /**
          * Asserts that the reference value is false.
          *
          * @returns assertion chain object.
          */
-        false(): this;
+        false(): TNarrowedAssertion<T>;
 
         /**
          * Asserts that the reference value is null.
          *
          * @returns assertion chain object.
          */
-        null(): this;
+        null(): TNarrowedAssertion<T>;
 
         /**
          * Asserts that the reference value is undefined.
          *
          * @returns assertion chain object.
          */
-        undefined(): this;
+        undefined(): TNarrowedAssertion<T>;
 
         /**
          * Asserts that the reference value is `NaN`.
          *
          * @returns assertion chain object.
          */
-        NaN(): this;
+        NaN(): TNarrowedAssertion<T>;
 
         // Tests
 
@@ -275,8 +277,8 @@ declare namespace expect {
          *
          * @returns assertion chain object.
          */
-        include(values: UnpackArray<Loosely<T> | Loosely<T>[]>): this;
-        include(values: string | string[]): this;
+        include(values: UnpackArray<Loosely<T> | Loosely<T>[]>): TNarrowedAssertion<T>;
+        include(values: string | string[]): TNarrowedAssertion<T>;
 
         /**
          * Asserts that the reference value (a string, array, or object) includes the provided values.
@@ -285,8 +287,8 @@ declare namespace expect {
          *
          * @returns assertion chain object.
          */
-        includes(values: UnpackArray<Loosely<T> | Loosely<T>[]>): this;
-        includes(values: string | string[]): this;
+        includes(values: UnpackArray<Loosely<T> | Loosely<T>[]>): TNarrowedAssertion<T>;
+        includes(values: string | string[]): TNarrowedAssertion<T>;
 
         /**
          * Asserts that the reference value (a string, array, or object) includes the provided values.
@@ -295,8 +297,8 @@ declare namespace expect {
          *
          * @returns assertion chain object.
          */
-        contain(values: UnpackArray<Loosely<T> | Loosely<T>[]>): this;
-        contain(values: string | string[]): this;
+        contain(values: UnpackArray<Loosely<T> | Loosely<T>[]>): TNarrowedAssertion<T>;
+        contain(values: string | string[]): TNarrowedAssertion<T>;
 
         /**
          * Asserts that the reference value (a string, array, or object) includes the provided values.
@@ -305,29 +307,29 @@ declare namespace expect {
          *
          * @returns assertion chain object.
          */
-        contains(values: UnpackArray<Loosely<T> | Loosely<T>[]>): this;
-        contains(values: string | string[]): this;
+        contains(values: UnpackArray<Loosely<T> | Loosely<T>[]>): TNarrowedAssertion<T>;
+        contains(values: string | string[]): TNarrowedAssertion<T>;
 
         /**
          * Asserts that the reference value exists (not null or undefined).
          *
          * @returns assertion chain object.
          */
-        exist(): this;
+        exist(): TNarrowedAssertion<T>;
 
         /**
          * Asserts that the reference value exists (not null or undefined).
          *
          * @returns assertion chain object.
          */
-        exists(): this;
+        exists(): TNarrowedAssertion<T>;
 
         /**
          * Asserts that the reference value has a length property equal to zero or is an object with no keys.
          *
          * @returns assertion chain object.
          */
-        empty(): this;
+        empty(): TNarrowedAssertion<T>;
 
         /**
          * Asserts that the reference value has a length property matching the provided size or an object with the specified number of keys.
@@ -336,7 +338,7 @@ declare namespace expect {
          *
          * @returns assertion chain object.
          */
-        length(size: T extends string | Buffer | object | any[] ? number : never): this;
+        length(size: T extends string | Buffer | object | any[] ? number : never): TNarrowedAssertion<T>;
 
         /**
          * Asserts that the reference value equals the provided value.
@@ -346,7 +348,7 @@ declare namespace expect {
          *
          * @returns assertion chain object.
          */
-        equal(value: T, options?: Hoek.deepEqual.Options): this;
+        equal(value: T, options?: Hoek.deepEqual.Options): TNarrowedAssertion<T>;
 
         /**
          * Asserts that the reference value equals the provided value.
@@ -356,21 +358,21 @@ declare namespace expect {
          *
          * @returns assertion chain object.
          */
-        equals(value: T, options?: Hoek.deepEqual.Options): this;
+        equals(value: T, options?: Hoek.deepEqual.Options): TNarrowedAssertion<T>;
 
         /**
          * Asserts that the reference value has the provided instanceof value.
          * 
          * @param type - the constructor function to be an instance of.
          */
-        instanceof(type: Class): this;
+        instanceof(type: Class): TNarrowedAssertion<T>;
 
         /**
          * Asserts that the reference value has the provided instanceof value.
          *
          * @param type - the constructor function to be an instance of.
          */
-        instanceOf(type: Class): this;
+        instanceOf(type: Class): TNarrowedAssertion<T>;
 
         /**
          * Asserts that the reference value's toString() representation matches the provided regular expression.
@@ -379,7 +381,7 @@ declare namespace expect {
          *
          * @returns assertion chain object.
          */
-        match(regex: RegExp): this;
+        match(regex: RegExp): TNarrowedAssertion<T>;
 
         /**
          * Asserts that the reference value's toString() representation matches the provided regular expression.
@@ -388,7 +390,7 @@ declare namespace expect {
          *
          * @returns assertion chain object.
          */
-        matches(regex: RegExp): this;
+        matches(regex: RegExp): TNarrowedAssertion<T>;
 
         /**
          * Asserts that the reference value satisfies the provided validator function.
@@ -397,7 +399,7 @@ declare namespace expect {
          *
          * @returns assertion chain object.
          */
-        satisfy(validator: (value: T) => boolean): this;
+        satisfy(validator: (value: T) => boolean): TNarrowedAssertion<T>;
 
         /**
          * Asserts that the reference value satisfies the provided validator function.
@@ -406,7 +408,7 @@ declare namespace expect {
          *
          * @returns assertion chain object.
          */
-        satisfies(validator: (value: T) => boolean): this;
+        satisfies(validator: (value: T) => boolean): TNarrowedAssertion<T>;
     }
 
     interface FunctionAssertion<T> extends Assertion<T> {
@@ -441,16 +443,16 @@ declare namespace expect {
          *
          * @returns assertion chain object.
          */
-        throw(): this;
-        throw(): this;
+        throw(): TNarrowedAssertion<T>;
+        throw(): TNarrowedAssertion<T>;
 
         /**
          * Asserts that the function reference value throws an exception when called.
          *
          * @returns assertion chain object.
          */
-        throws(): this;
-        throws(): this;
+        throws(): TNarrowedAssertion<T>;
+        throws(): TNarrowedAssertion<T>;
     }
 
     interface StringAssertion<T> extends Assertion<T> {
@@ -462,7 +464,7 @@ declare namespace expect {
          *
          * @returns assertion chain object.
          */
-        startWith(value: string): this;
+        startWith(value: string): TNarrowedAssertion<T>;
 
         /**
          * Asserts that the reference value (a string) starts with the provided value.
@@ -471,7 +473,7 @@ declare namespace expect {
          *
          * @returns assertion chain object.
          */
-        startsWith(value: string): this;
+        startsWith(value: string): TNarrowedAssertion<T>;
 
         /**
          * Asserts that the reference value (a string) ends with the provided value.
@@ -480,7 +482,7 @@ declare namespace expect {
          *
          * @returns assertion chain object.
          */
-        endWith(value: string): this;
+        endWith(value: string): TNarrowedAssertion<T>;
 
         /**
          * Asserts that the reference value (a string) ends with the provided value.
@@ -489,7 +491,7 @@ declare namespace expect {
          *
          * @returns assertion chain object.
          */
-        endsWith(value: string): this;
+        endsWith(value: string): TNarrowedAssertion<T>;
     }
 
     interface NumberAssertion<T> extends Assertion<T> {
@@ -501,7 +503,7 @@ declare namespace expect {
          *
          * @returns assertion chain object.
          */
-        above(value: T): this;
+        above(value: T): TNarrowedAssertion<T>;
 
         /**
          * Asserts that the reference value is greater than (>) the provided value.
@@ -510,7 +512,7 @@ declare namespace expect {
          *
          * @returns assertion chain object.
          */
-        greaterThan(value: T): this;
+        greaterThan(value: T): TNarrowedAssertion<T>;
 
         /**
          * Asserts that the reference value is at least (>=) the provided value.
@@ -519,7 +521,7 @@ declare namespace expect {
          *
          * @returns assertion chain object.
          */
-        least(value: T): this;
+        least(value: T): TNarrowedAssertion<T>;
 
         /**
          * Asserts that the reference value is at least (>=) the provided value.
@@ -528,7 +530,7 @@ declare namespace expect {
          *
          * @returns assertion chain object.
          */
-        min(value: T): this;
+        min(value: T): TNarrowedAssertion<T>;
 
         /**
          * Asserts that the reference value is less than (<) the provided value.
@@ -537,7 +539,7 @@ declare namespace expect {
          *
          * @returns assertion chain object.
          */
-        below(value: T): this;
+        below(value: T): TNarrowedAssertion<T>;
 
         /**
          * Asserts that the reference value is less than (<) the provided value.
@@ -546,7 +548,7 @@ declare namespace expect {
          *
          * @returns assertion chain object.
          */
-        lessThan(value: T): this;
+        lessThan(value: T): TNarrowedAssertion<T>;
 
         /**
          * Asserts that the reference value is at most (<=) the provided value.
@@ -555,7 +557,7 @@ declare namespace expect {
          *
          * @returns assertion chain object.
          */
-        most(value: T): this;
+        most(value: T): TNarrowedAssertion<T>;
 
         /**
          * Asserts that the reference value is at most (<=) the provided value.
@@ -564,7 +566,7 @@ declare namespace expect {
          *
          * @returns assertion chain object.
          */
-        max(value: T): this;
+        max(value: T): TNarrowedAssertion<T>;
 
         /**
          * Asserts that the reference value is within (from <= value <= to) the provided values.
@@ -574,7 +576,7 @@ declare namespace expect {
          *
          * @returns assertion chain object.
          */
-        within(from: T, to: T): this;
+        within(from: T, to: T): TNarrowedAssertion<T>;
 
         /**
          * Asserts that the reference value is within (from <= value <= to) the provided values.
@@ -584,7 +586,7 @@ declare namespace expect {
          *
          * @returns assertion chain object.
          */
-        range(from: T, to: T): this;
+        range(from: T, to: T): TNarrowedAssertion<T>;
 
         /**
          * Asserts that the reference value is between but not equal (from < value < to) the provided values.
@@ -594,7 +596,7 @@ declare namespace expect {
          *
          * @returns assertion chain object.
          */
-        between(from: T, to: T): this;
+        between(from: T, to: T): TNarrowedAssertion<T>;
 
         /**
          * Asserts that the reference value is about the provided value within a delta margin of difference.
@@ -604,7 +606,7 @@ declare namespace expect {
          *
          * @returns assertion chain object.
          */
-        about(value: T extends number ? T : never, delta: T extends number ? T : never): this;
+        about(value: T extends number ? T : never, delta: T extends number ? T : never): TNarrowedAssertion<T>;
     }
 
     interface PromiseAssertion<T> extends Assertion<T> {

--- a/lib/index.js
+++ b/lib/index.js
@@ -444,12 +444,12 @@ internals.reject = async function (...args/* type, message */) {
             thrown = err;
         }
 
-        internals.assert(this, !this._flags.not || !arguments.length, 'Cannot specify arguments when expecting not to reject');
+        internals.assert(this, !this._flags.not || !args.length, 'Cannot specify arguments when expecting not to reject');
 
         if (thrown) {
 
-            internals.assert(this, arguments.length < 2 || message, 'Can not assert with invalid message argument type');
-            internals.assert(this, arguments.length < 1 || message !== null || typeof type === 'function', 'Can not assert with invalid type argument');
+            internals.assert(this, args.length < 2 || message, 'Can not assert with invalid message argument type');
+            internals.assert(this, args.length < 1 || message !== null || typeof type === 'function', 'Can not assert with invalid type argument');
 
             if (type) {
                 this.assert(thrown instanceof type, 'reject with ' + (type.name || 'provided type'));

--- a/test/index.ts
+++ b/test/index.ts
@@ -194,6 +194,7 @@ const throws = () => {
 };
 
 Code.expect(throws).to.throw(CustomError, 'Oh no!');
+Code.expect(() => { }).to.not.throw().and.to.be.a.function();
 
 const typedRejection = Promise.reject(new CustomError('Oh no!'));
 await expect.type<CustomError>(Code.expect(typedRejection).to.reject(CustomError, 'Oh no!'));

--- a/test/index.ts
+++ b/test/index.ts
@@ -196,10 +196,10 @@ const throws = () => {
 Code.expect(throws).to.throw(CustomError, 'Oh no!');
 
 const typedRejection = Promise.reject(new CustomError('Oh no!'));
-await expect.type<Promise<CustomError>>(Code.expect(typedRejection).to.reject(CustomError, 'Oh no!'));
-await expect.type<Promise<CustomError>>(Code.expect(typedRejection).rejects(CustomError, 'Oh no!'));
+await expect.type<CustomError>(Code.expect(typedRejection).to.reject(CustomError, 'Oh no!'));
+await expect.type<CustomError>(Code.expect(typedRejection).rejects(CustomError, 'Oh no!'));
 
-await expect.type<Promise<null>>(Code.expect(Promise.resolve(true)).to.not.reject());
+await expect.type<null>(Code.expect(Promise.resolve(true)).to.not.reject());
 
 function foo(): number | undefined {
     return 123;


### PR DESCRIPTION
This fixes multiple issues:

1. Major: The typings for `reject()` were clearly wrong, as it does not return a `Promise` but the rejected error value.
2. Narrow the argument list and returned type when `reject()` and `throw()` is called with `.not` applied. This fixes the primary issue in #170.
3. Only allow `throw()` to be called on `functions`.
4. Minor: Don't use `arguments`.

