### PR TITLE
Drop node v12, support node v18

### DIFF
--- a/.github/workflows/ci-module.yml
+++ b/.github/workflows/ci-module.yml
@@ -3,6 +3,7 @@ name: ci
 on:
   push:
     branches:
+      - v9
       - master
   pull_request:
   workflow_dispatch:
@@ -10,3 +11,5 @@ on:
 jobs:
   test:
     uses: hapijs/.github/.github/workflows/ci-module.yml@master
+    with:
+      min-node-version: 14

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,6 +1,6 @@
-Copyright (c) 2014-2012, Sideway Inc, and project contributors  
-Copyright (c) 2014, Walmart  
-Copyright (c) 2011-2014 Jake Luer  
+Copyright (c) 2014-2022, Sideway Inc, and project contributors
+Copyright (c) 2014, Walmart
+Copyright (c) 2011-2014 Jake Luer
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:

--- a/lib/index.js
+++ b/lib/index.js
@@ -50,9 +50,9 @@ internals.atUnnamedRx = /^\s*at (?:async )?(.+)\:(\d+)\:(\d+)\)?$/;
 
 exports.thrownAt = function (error) {
 
-    error = error || new Error();
+    error = error ?? new Error();
     const stack = typeof error.stack === 'string' ? error.stack : '';
-    const frame = stack.replace(error.toString(), '').split('\n').slice(1).filter(internals.filterLocal)[0] || '';
+    const frame = stack.replace(error.toString(), '').split('\n').slice(1).filter(internals.filterLocal)[0] ?? '';
     const at = frame.match(frame.includes('(') ? internals.atNamedRx : internals.atUnnamedRx);
     return Array.isArray(at) ? {
         filename: at[1],
@@ -83,7 +83,7 @@ exports.expect = function (value, prefix) {
 internals.Assertion = function (ref, prefix, location, at) {
 
     this._ref = ref;
-    this._prefix = prefix || '';
+    this._prefix = prefix ?? '';
     this._location = location;
     this._at = at;
     this._flags = {};
@@ -135,7 +135,7 @@ internals.Assertion.prototype.assert = function (result, verb, actual, expected)
     Error.captureStackTrace(error, this.assert);
     error.actual = actual;
     error.expected = expected;
-    error.at = exports.thrownAt(error) || this._at;
+    error.at = exports.thrownAt(error) ?? this._at;
     throw error;
 };
 
@@ -193,7 +193,7 @@ internals.addMethod = function (names, fn) {
 internals.addMethod('error', function (...args /* type, message */) {
 
     const type = args.length && typeof args[0] !== 'string' && !(args[0] instanceof RegExp) ? args[0] : Error;
-    const lastArg = args[1] || args[0];
+    const lastArg = args[1] ?? args[0];
     const message = typeof lastArg === 'string' || lastArg instanceof RegExp ? lastArg : null;
     const err = this._ref;
 
@@ -296,7 +296,7 @@ internals.addMethod('length', internals.length);
 
 internals.equal = function (value, options) {
 
-    options = options || {};
+    options = options ?? {};
     const settings = Hoek.applyToDefaults({ prototype: exports.settings.comparePrototypes, deepFunction: true }, options);
 
     const compare = this._flags.shallow ? (a, b) => a === b
@@ -397,7 +397,7 @@ internals.throw = function (...args /* type, message */) {
     internals.assert(this, !this._flags.not || !args.length, 'Cannot specify arguments when expecting not to throw');
 
     const type = args.length && typeof args[0] !== 'string' && !(args[0] instanceof RegExp) ? args[0] : null;
-    const lastArg = args[1] || args[0];
+    const lastArg = args[1] ?? args[0];
     const message = typeof lastArg === 'string' || lastArg instanceof RegExp ? lastArg : null;
 
     let thrown = false;
@@ -413,7 +413,7 @@ internals.throw = function (...args /* type, message */) {
         }
 
         if (message !== null) {
-            const error = err.message || '';
+            const error = err.message ?? '';
             this.assert(typeof message === 'string' ? error === message : error.match(message), 'throw an error with specified message', error, message);
         }
 
@@ -433,7 +433,7 @@ internals.reject = async function (...args/* type, message */) {
         internals.assert(this, internals.isPromise(this._ref), 'Can only assert reject on promises');
 
         const type = args.length && typeof args[0] !== 'string' && !(args[0] instanceof RegExp) ? args[0] : null;
-        const lastArg = args[1] || args[0];
+        const lastArg = args[1] ?? args[0];
         const message = typeof lastArg === 'string' || lastArg instanceof RegExp ? lastArg : null;
 
         let thrown = null;
@@ -456,7 +456,7 @@ internals.reject = async function (...args/* type, message */) {
             }
 
             if (message !== null) {
-                const error = thrown.message || '';
+                const error = thrown.message ?? '';
                 this.assert(typeof message === 'string' ? error === message : error.match(message), 'reject with an error with specified message', error, message);
             }
 
@@ -479,7 +479,7 @@ internals.addMethod(['reject', 'rejects'], internals.reject);
 
 internals.isPromise = function (promise) {
 
-    return promise && typeof promise.then === 'function';
+    return typeof promise?.then === 'function';
 };
 
 

--- a/package.json
+++ b/package.json
@@ -23,8 +23,9 @@
   },
   "devDependencies": {
     "@hapi/eslint-plugin": "*",
-    "@hapi/lab": "24.x.x",
-    "typescript": "~4.0.2"
+    "@hapi/lab": "25.0.0-beta.0",
+    "@types/node": "^17.0.25",
+    "typescript": "~4.6.3"
   },
   "scripts": {
     "test": "lab -t 100 -L -Y",

--- a/test/index.js
+++ b/test/index.js
@@ -586,9 +586,9 @@ describe('expect()', () => {
 
             it('invalidates assertion (anonymous type)', () => {
 
-                const Custom = function () { };
-                Util.inherits(Custom, Error);
-                delete Custom.name; // Ensure that the type is anonymous
+                const Custom = class extends Error {
+                    static name = undefined; // Ensure that the type is anonymous
+                };
 
                 try {
                     Code.expect(error).to.be.an.error(Custom);


### PR DESCRIPTION
This work drops node v12 support, introduces node v18 support, and updates the version of typescript used for testing.