### PR TITLE
Fix license years for Sideway versus contributors

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,4 +1,5 @@
-Copyright (c) 2014-2022, Sideway Inc, and project contributors
+Copyright (c) 2014-2022, Project contributors
+Copyright (c) 2014-2020, Sideway Inc
 Copyright (c) 2014, Walmart
 Copyright (c) 2011-2014 Jake Luer
 All rights reserved.


### PR DESCRIPTION
In #175 I "fixed" the copyright years from `2014-2012` to `2014-2022`.  It turns out that `2012` was actually a typo for `2020` rather than `2022` (https://github.com/hapijs/code/commit/1f96db84ebba155810d0bcc72313b4043a709f98), so here I've split it into two copyright lines for Sideway and for project contributors, similarly to https://github.com/hapijs/hoek/pull/378.