### PR TITLE
Fix `reject()` types

### DIFF
--- a/API.md
+++ b/API.md
@@ -625,7 +625,7 @@ and compared to the provided optional requirements where:
 - `message` a string or regular expression matching the rejected error `message` property. Note that a string
   must provide a full match.
 
-Returns the rejected error object.
+Returns a promise resolving to the rejected error object.
 
 ```js
 const NodeUtil = require('util');

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -616,10 +616,10 @@ declare namespace expect {
          * @param type - constructor function the error must be an instance of.
          * @param message - string or regular expression the error message must match.
          *
-         * @returns rejected value.
+         * @returns a promise resolving to the rejected value.
          */
-        reject<E extends {}>(type: Class<E>, message?: string | RegExp): E;
-        reject<E = unknown>(message?: string | RegExp): E;
+        reject<E extends {}>(type: Class<E>, message?: string | RegExp): Promise<E>;
+        reject<E = unknown>(message?: string | RegExp): Promise<E>;
 
         /**
          * Asserts that the Promise reference value rejects with an exception when called.
@@ -627,10 +627,10 @@ declare namespace expect {
          * @param type - constructor function the error must be an instance of.
          * @param message - string or regular expression the error message must match.
          *
-         * @returns rejected value.
+         * @returns a promise resolving to the rejected value.
          */
-        rejects<E extends {}>(type: Class<E>, message?: string | RegExp): E;
-        rejects<E = unknown>(message?: string | RegExp): E;
+        rejects<E extends {}>(type: Class<E>, message?: string | RegExp): Promise<E>;
+        rejects<E = unknown>(message?: string | RegExp): Promise<E>;
     }
 
     interface Not_PromiseAssertion<T> extends BaseAssertion<T> {
@@ -638,15 +638,15 @@ declare namespace expect {
         /**
          * Asserts that the Promise reference value rejects with an exception when called.
          *
-         * @returns null.
+         * @returns a promise resolving to null.
          */
-        reject(): null;
+        reject(): Promise<null>;
 
         /**
          * Asserts that the Promise reference value rejects with an exception when called.
          *
-         * @returns null.
+         * @returns a promise resolving to null.
          */
-        rejects(): null;
+        rejects(): Promise<null>;
     }
 }

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   },
   "devDependencies": {
     "@hapi/eslint-plugin": "*",
-    "@hapi/lab": "25.0.0-beta.1",
+    "@hapi/lab": "^25.0.1",
     "@types/node": "^17.0.25",
     "typescript": "~4.6.3"
   },

--- a/test/index.ts
+++ b/test/index.ts
@@ -200,10 +200,10 @@ Code.expect(throws).to.throw(CustomError, 'Oh no!');
 Code.expect(() => { }).to.not.throw().and.to.be.a.function();
 
 const typedRejection = Promise.reject(new CustomError('Oh no!'));
-await expect.type<CustomError>(Code.expect(typedRejection).to.reject(CustomError, 'Oh no!'));
-await expect.type<CustomError>(Code.expect(typedRejection).rejects(CustomError, 'Oh no!'));
+await expect.type<Promise<CustomError>>(Code.expect(typedRejection).to.reject(CustomError, 'Oh no!'));
+await expect.type<Promise<CustomError>>(Code.expect(typedRejection).rejects(CustomError, 'Oh no!'));
 
-await expect.type<null>(Code.expect(Promise.resolve(true)).to.not.reject());
+await expect.type<Promise<null>>(Code.expect(Promise.resolve(true)).to.not.reject());
 
 function foo(): number | undefined {
     return 123;

--- a/test/index.ts
+++ b/test/index.ts
@@ -186,8 +186,8 @@ Code.expect(type2).to.equal({ a: [1] }, { skip: ['c'] });
 
 const rejection = Promise.reject(new Error('Oh no!'));
 
-await expect.type<Promise<any>>(Code.expect(rejection).to.reject('Oh no!'));
-await expect.type<Promise<any>>(Code.expect(rejection).rejects('Oh no!'));
+expect.type<Promise<any>>(Code.expect(rejection).to.reject('Oh no!'));
+expect.type<Promise<any>>(Code.expect(rejection).rejects('Oh no!'));
 
 class CustomError extends Error { }
 
@@ -200,10 +200,10 @@ Code.expect(throws).to.throw(CustomError, 'Oh no!');
 Code.expect(() => { }).to.not.throw().and.to.be.a.function();
 
 const typedRejection = Promise.reject(new CustomError('Oh no!'));
-await expect.type<Promise<CustomError>>(Code.expect(typedRejection).to.reject(CustomError, 'Oh no!'));
-await expect.type<Promise<CustomError>>(Code.expect(typedRejection).rejects(CustomError, 'Oh no!'));
+expect.type<Promise<CustomError>>(Code.expect(typedRejection).to.reject(CustomError, 'Oh no!'));
+expect.type<Promise<CustomError>>(Code.expect(typedRejection).rejects(CustomError, 'Oh no!'));
 
-await expect.type<Promise<null>>(Code.expect(Promise.resolve(true)).to.not.reject());
+expect.type<Promise<null>>(Code.expect(Promise.resolve(true)).to.not.reject());
 
 function foo(): number | undefined {
     return 123;


### PR DESCRIPTION
Looks like the new types in https://github.com/hapijs/code/pull/171 weren't 100% right: `reject()` should still return a Promise (it's an [async function](https://github.com/hapijs/code/blob/a4ab995a4372fec067778ba1666e9c71ccfd9218/lib/index.js#L430) after all!)